### PR TITLE
Auto-regenerate .bazelrc.user on nix develop entry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,11 @@
               export C_INCLUDE_PATH="${pkgs.lib.makeSearchPathOutput "dev" "include" x11Libs}:$C_INCLUDE_PATH"
               export CGO_CFLAGS="-I${pkgs.xorg.libX11.dev}/include -I${pkgs.xorg.xorgproto}/include $CGO_CFLAGS"
               export CGO_LDFLAGS="-L${pkgs.xorg.libX11}/lib $CGO_LDFLAGS"
+
+              # Auto-regenerate .bazelrc.user with correct Nix paths for this machine
+              if [ -f "./scripts/gen-bazelrc-user.sh" ]; then
+                ./scripts/gen-bazelrc-user.sh --quiet
+              fi
             ''}
 
             # Bazel configuration

--- a/scripts/gen-bazelrc-user.sh
+++ b/scripts/gen-bazelrc-user.sh
@@ -2,69 +2,130 @@
 # Generate .bazelrc.user with Nix store paths for X11 development
 # This script must be run from within the Nix environment (nix develop)
 #
-# Usage: ./scripts/gen-bazelrc-user.sh
+# Usage: ./scripts/gen-bazelrc-user.sh [--quiet]
+#
+# Options:
+#   --quiet    Only output if changes were made
 
 set -e
 
 BAZELRC_USER=".bazelrc.user"
+QUIET=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --quiet|-q)
+            QUIET=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
 
 # Check we're in a Nix environment
-if ! which nix >/dev/null 2>&1 || [ -z "$IN_NIX_SHELL" ] && [ -z "$NIX_BUILD_TOP" ]; then
-    echo "Warning: Not in a Nix environment. Run 'nix develop' first." >&2
+if [ -z "$C_INCLUDE_PATH" ] && ! command -v pkg-config >/dev/null 2>&1; then
+    echo "Error: Not in a Nix environment. Run 'nix develop' first." >&2
+    exit 1
 fi
 
-echo "Generating $BAZELRC_USER..."
-
-cat > "$BAZELRC_USER" << 'EOF'
+# Generate content to a temporary variable first
+generate_content() {
+    cat << 'EOF'
 # Auto-generated Nix X11 paths for Bazel CGO compilation
 # These paths are machine-specific and should not be committed
 # Regenerate with: ./scripts/gen-bazelrc-user.sh
+# Or enter nix develop (auto-regenerates on entry)
 
 EOF
 
-# X11 libraries that need include paths (-dev packages)
-X11_LIBS=(
-    libx11
-    libxext
-    libxfixes
-    libxrandr
-    libxrender
-    libxcursor
-    libxinerama
-    libxi
-    libxxf86vm
-    libglvnd
-    alsa-lib
-)
+    echo "# Include paths for compilation"
 
-echo "# Include paths for compilation" >> "$BAZELRC_USER"
-
-for lib in "${X11_LIBS[@]}"; do
-    # Find the -dev package
-    path=$(find /nix/store -maxdepth 1 -name "*-${lib}*-dev" -type d 2>/dev/null | head -1)
-    if [ -n "$path" ] && [ -d "$path/include" ]; then
-        echo "build --copt=-I${path}/include" >> "$BAZELRC_USER"
+    # Use C_INCLUDE_PATH from Nix environment (most reliable)
+    # This is set by the Nix shell hook and contains all -dev package includes
+    if [ -n "$C_INCLUDE_PATH" ]; then
+        IFS=':' read -ra INCLUDE_PATHS <<< "$C_INCLUDE_PATH"
+        for path in "${INCLUDE_PATHS[@]}"; do
+            if [ -n "$path" ] && [ -d "$path" ]; then
+                echo "build --copt=-I${path}"
+            fi
+        done
     fi
-done
 
-# xorgproto doesn't have a -dev suffix
-xorgproto=$(find /nix/store -maxdepth 1 -name "*xorgproto*" -type d 2>/dev/null | grep -v "\.drv$" | head -1)
-if [ -n "$xorgproto" ] && [ -d "$xorgproto/include" ]; then
-    echo "build --copt=-I${xorgproto}/include" >> "$BAZELRC_USER"
+    # Also add pkg-config paths as fallback (may add some duplicates, but that's OK)
+    if command -v pkg-config >/dev/null 2>&1; then
+        PKG_CONFIG_LIBS=(x11 xext xfixes xrandr xrender xcursor xinerama xi xxf86vm gl alsa)
+        declare -A seen_includes
+
+        for lib in "${PKG_CONFIG_LIBS[@]}"; do
+            if pkg-config --exists "$lib" 2>/dev/null; then
+                cflags=$(pkg-config --cflags "$lib" 2>/dev/null || true)
+                for flag in $cflags; do
+                    if [[ $flag == -I* ]]; then
+                        path="${flag#-I}"
+                        if [ -z "${seen_includes[$path]}" ] && [ -d "$path" ]; then
+                            seen_includes["$path"]=1
+                            echo "build --copt=-I${path}"
+                        fi
+                    fi
+                done
+            fi
+        done
+    fi
+
+    echo ""
+    echo "# Library paths for linking"
+
+    # Use pkg-config for library paths (more reliable than scanning)
+    if command -v pkg-config >/dev/null 2>&1; then
+        PKG_CONFIG_LIBS=(x11 xext xfixes xrandr xrender xcursor xinerama xi xxf86vm gl alsa)
+        declare -A seen_libs
+
+        for lib in "${PKG_CONFIG_LIBS[@]}"; do
+            if pkg-config --exists "$lib" 2>/dev/null; then
+                libs=$(pkg-config --libs-only-L "$lib" 2>/dev/null || true)
+                for flag in $libs; do
+                    if [[ $flag == -L* ]]; then
+                        path="${flag#-L}"
+                        if [ -z "${seen_libs[$path]}" ] && [ -d "$path" ]; then
+                            seen_libs["$path"]=1
+                            echo "build --linkopt=-L${path}"
+                        fi
+                    fi
+                done
+            fi
+        done
+    fi
+}
+
+# Generate new content
+NEW_CONTENT=$(generate_content)
+
+# Check if file exists and compare hash
+if [ -f "$BAZELRC_USER" ]; then
+    OLD_HASH=$(md5sum "$BAZELRC_USER" 2>/dev/null | cut -d' ' -f1 || echo "")
+    NEW_HASH=$(echo "$NEW_CONTENT" | md5sum | cut -d' ' -f1)
+
+    if [ "$OLD_HASH" = "$NEW_HASH" ]; then
+        # No changes needed
+        if [ "$QUIET" = false ]; then
+            echo "$BAZELRC_USER is up to date."
+        fi
+        exit 0
+    fi
 fi
 
-echo "" >> "$BAZELRC_USER"
-echo "# Library paths for linking" >> "$BAZELRC_USER"
+# Write new content
+echo "$NEW_CONTENT" > "$BAZELRC_USER"
 
-for lib in "${X11_LIBS[@]}"; do
-    # Find the runtime library package (not -dev, not -doc)
-    path=$(find /nix/store -maxdepth 1 -type d -name "*-${lib}-[0-9]*" 2>/dev/null | grep -v '\-dev$' | grep -v '\-doc$' | head -1)
-    if [ -n "$path" ] && [ -d "$path/lib" ]; then
-        echo "build --linkopt=-L${path}/lib" >> "$BAZELRC_USER"
-    fi
-done
-
-echo "Generated $BAZELRC_USER with $(grep -c "^build" "$BAZELRC_USER") entries."
-echo ""
-echo "Contents:"
-cat "$BAZELRC_USER"
+# Report changes
+ENTRY_COUNT=$(grep -c "^build" "$BAZELRC_USER" || echo 0)
+if [ "$QUIET" = false ]; then
+    echo "Generated $BAZELRC_USER with $ENTRY_COUNT entries."
+    echo ""
+    echo "Contents:"
+    cat "$BAZELRC_USER"
+else
+    echo "Regenerated $BAZELRC_USER (paths updated for this machine)"
+fi


### PR DESCRIPTION
## Summary
- Makes the repo portable across machines by auto-regenerating `.bazelrc.user` with correct Nix store paths on `nix develop` entry
- Rewrote `gen-bazelrc-user.sh` to use `C_INCLUDE_PATH` from Nix environment instead of slow `/nix/store` scans
- Added hash-based change detection to avoid unnecessary file writes

## Test plan
- [x] Tested build on local machine
- [x] Tested build on splinter0.local - paths auto-regenerated and build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)