### PR TITLE
P1.4: Fix glob mismatch in advisor

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,13 @@ gazelle_dependencies()
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 go_repository(
+    name = "com_github_bmatcuk_doublestar_v4",
+    importpath = "github.com/bmatcuk/doublestar/v4",
+    sum = "h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=",
+    version = "v4.10.0",
+)
+
+go_repository(
     name = "com_github_hajimehoshi_ebiten_v2",
     importpath = "github.com/hajimehoshi/ebiten/v2",
     sum = "h1:WuNgM24uJxwdLZLqM8SXLAGVBof/45udRjo2tJoTpM0=",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tedks/CodingGame
 go 1.24.7
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
 	github.com/ebitengine/purego v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 h1:+kz5iTT3L7uU+VhlMfTb8hHcxLO3TlaELlX8wa4XjA0=
 github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1/go.mod h1:lKJoeixeJwnFmYsBny4vvCJGVFc3aYDalhuDsfZzWHI=
 github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=

--- a/internal/advisor/BUILD.bazel
+++ b/internal/advisor/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/harness",
+        "@com_github_bmatcuk_doublestar_v4//:doublestar",
     ],
 )
 

--- a/internal/advisor/config.go
+++ b/internal/advisor/config.go
@@ -17,6 +17,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 // TriggerMode defines when an advisor runs
@@ -134,8 +136,11 @@ func (c *Config) MatchesFile(filePath string) bool {
 		return true
 	}
 
+	slashPath := filepath.ToSlash(filePath)
+	baseName := filepath.Base(filePath)
 	for _, pattern := range c.FocusPatterns {
-		matched, err := filepath.Match(pattern, filePath)
+		slashPattern := filepath.ToSlash(pattern)
+		matched, err := doublestar.Match(slashPattern, slashPath)
 		if err != nil {
 			// Invalid pattern, skip it
 			continue
@@ -146,7 +151,7 @@ func (c *Config) MatchesFile(filePath string) bool {
 
 		// Also try matching against the base name for patterns without path separators
 		if !containsPathSeparator(pattern) {
-			matched, err = filepath.Match(pattern, filepath.Base(filePath))
+			matched, err = doublestar.Match(slashPattern, baseName)
 			if err == nil && matched {
 				return true
 			}

--- a/internal/advisor/config_test.go
+++ b/internal/advisor/config_test.go
@@ -211,6 +211,18 @@ func TestConfig_MatchesFile(t *testing.T) {
 			filePath: "lib/main.go",
 			want:     false,
 		},
+		{
+			name:     "double star directory match",
+			patterns: []string{"**/auth/**"},
+			filePath: "src/auth/login.go",
+			want:     true,
+		},
+		{
+			name:     "double star extension match",
+			patterns: []string{"**/*.go"},
+			filePath: "src/internal/main.go",
+			want:     true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/harness/claude/parser_integration_test.go
+++ b/internal/harness/claude/parser_integration_test.go
@@ -17,18 +17,18 @@ var claudeStreamJSONSamples = []struct {
 	expectedType harness.EventType
 }{
 	{
-		name: "system_init",
-		json: `{"type":"system","subtype":"init","cwd":"/home/user/project","session_id":"abc-123","tools":["Task","Bash","Read"],"mcp_servers":[],"model":"claude-sonnet-4-5-20250929","permissionMode":"bypassPermissions","slash_commands":["compact"],"apiKeySource":"none","claude_code_version":"2.1.19","output_style":"default","agents":["Bash"],"skills":[],"plugins":[],"uuid":"xyz-456"}`,
+		name:         "system_init",
+		json:         `{"type":"system","subtype":"init","cwd":"/home/user/project","session_id":"abc-123","tools":["Task","Bash","Read"],"mcp_servers":[],"model":"claude-sonnet-4-5-20250929","permissionMode":"bypassPermissions","slash_commands":["compact"],"apiKeySource":"none","claude_code_version":"2.1.19","output_style":"default","agents":["Bash"],"skills":[],"plugins":[],"uuid":"xyz-456"}`,
 		expectedType: harness.EventTurnStart,
 	},
 	{
-		name: "assistant_text_response",
-		json: `{"type":"assistant","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_123","type":"message","role":"assistant","content":[{"type":"text","text":"Hello! How can I help you today?"}],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":2,"output_tokens":10}},"parent_tool_use_id":null,"session_id":"abc-123","uuid":"def-789"}`,
+		name:         "assistant_text_response",
+		json:         `{"type":"assistant","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_123","type":"message","role":"assistant","content":[{"type":"text","text":"Hello! How can I help you today?"}],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":2,"output_tokens":10}},"parent_tool_use_id":null,"session_id":"abc-123","uuid":"def-789"}`,
 		expectedType: harness.EventText,
 	},
 	{
-		name: "result_success",
-		json: `{"type":"result","subtype":"success","is_error":false,"duration_ms":1500,"duration_api_ms":1400,"num_turns":1,"result":"Hello! How can I help you today?","session_id":"abc-123","total_cost_usd":0.001,"usage":{"input_tokens":2,"output_tokens":10},"modelUsage":{},"permission_denials":[],"uuid":"ghi-012"}`,
+		name:         "result_success",
+		json:         `{"type":"result","subtype":"success","is_error":false,"duration_ms":1500,"duration_api_ms":1400,"num_turns":1,"result":"Hello! How can I help you today?","session_id":"abc-123","total_cost_usd":0.001,"usage":{"input_tokens":2,"output_tokens":10},"modelUsage":{},"permission_denials":[],"uuid":"ghi-012"}`,
 		expectedType: harness.EventTurnComplete,
 	},
 }

--- a/internal/mapview/mapview.go
+++ b/internal/mapview/mapview.go
@@ -172,10 +172,10 @@ func New(projectPath string, width, height int) (*MapView, error) {
 		tileMap:           tileMap,
 		treeLayout:        treeLayout,
 		bgColor:           color.RGBA{20, 20, 30, 255},
-		gridColor:     color.RGBA{60, 60, 80, 255},
-		fogColor:      color.RGBA{40, 40, 50, 200},
-		revealedColor: color.RGBA{100, 120, 150, 255},
-		selectedColor: color.RGBA{255, 200, 100, 180}, // Yellow highlight for selection
+		gridColor:         color.RGBA{60, 60, 80, 255},
+		fogColor:          color.RGBA{40, 40, 50, 200},
+		revealedColor:     color.RGBA{100, 120, 150, 255},
+		selectedColor:     color.RGBA{255, 200, 100, 180}, // Yellow highlight for selection
 		// Belt colors for dataflow view
 		beltImportColor:      color.RGBA{100, 150, 200, 255}, // Blue for imports
 		beltInheritanceColor: color.RGBA{200, 150, 100, 255}, // Orange for inheritance

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -42,22 +42,22 @@ type Message struct {
 
 // Panel size constants
 const (
-	MinPanelHeight     = 60  // Minimized height (just input bar)
-	MaxPanelHeight     = 500 // Maximum expanded height
-	LineHeight         = 16  // Height per line of text
-	InputAreaHeight    = 50  // Height of the input area at bottom
-	MessagePadding     = 8   // Padding around messages
-	PanelGrowthPerMsg  = 40  // How much to grow per message (approximate)
-	AnimationSpeed     = 8   // Pixels per frame for smooth animation
-	DragHandleHeight   = 8   // Height of the drag handle area at top
+	MinPanelHeight    = 60  // Minimized height (just input bar)
+	MaxPanelHeight    = 500 // Maximum expanded height
+	LineHeight        = 16  // Height per line of text
+	InputAreaHeight   = 50  // Height of the input area at bottom
+	MessagePadding    = 8   // Padding around messages
+	PanelGrowthPerMsg = 40  // How much to grow per message (approximate)
+	AnimationSpeed    = 8   // Pixels per frame for smooth animation
+	DragHandleHeight  = 8   // Height of the drag handle area at top
 )
 
 // PromptPanel provides a conversation interface with Claude.
 type PromptPanel struct {
 	// Position and size
-	X, Y          int
-	Width         int
-	screenHeight  int // Full screen height for calculating position
+	X, Y         int
+	Width        int
+	screenHeight int // Full screen height for calculating position
 
 	// Size state
 	minimized       bool


### PR DESCRIPTION
## Summary
- switch advisor glob matching to doublestar for ** support
- add ** pattern tests
- add doublestar dependency and gofmt alignment updates

## Testing
- xvfb-run -a -s '-screen 0 1024x768x24 -ac' nix develop --command bazel test //... (fails: claude_integration_test requires --verbose with --output-format=stream-json; race_verification_test requires race flag)
- nix develop --command bazel build //...