### PR TITLE
P1.5: Remove dead/unused code

### DIFF
--- a/internal/advisor/pool.go
+++ b/internal/advisor/pool.go
@@ -33,10 +33,6 @@ type PoolListener interface {
 	OnAdvisorAdded(advisor *Advisor)
 	// OnAdvisorRemoved is called when an advisor is removed from the pool
 	OnAdvisorRemoved(advisorID string)
-	// OnInsightGenerated is called when an advisor produces an insight
-	OnInsightGenerated(insight *Insight)
-	// OnAdvisorStateChanged is called when an advisor changes state
-	OnAdvisorStateChanged(advisor *Advisor, oldState, newState AdvisorState)
 }
 
 // NewPool creates a new advisor pool
@@ -348,32 +344,6 @@ type PoolMetrics struct {
 	TotalInsights    int
 	AcceptedInsights int
 	RejectedInsights int
-}
-
-// notifyInsight notifies all listeners about a new insight
-func (p *Pool) notifyInsight(insight *Insight) {
-	p.mu.RLock()
-	listeners := make([]PoolListener, len(p.listeners))
-	copy(listeners, p.listeners)
-	p.mu.RUnlock()
-
-	// Call listeners synchronously (they should be fast callbacks)
-	for _, listener := range listeners {
-		listener.OnInsightGenerated(insight)
-	}
-}
-
-// notifyStateChange notifies all listeners about an advisor state change
-func (p *Pool) notifyStateChange(advisor *Advisor, oldState, newState AdvisorState) {
-	p.mu.RLock()
-	listeners := make([]PoolListener, len(p.listeners))
-	copy(listeners, p.listeners)
-	p.mu.RUnlock()
-
-	// Call listeners synchronously (they should be fast callbacks)
-	for _, listener := range listeners {
-		listener.OnAdvisorStateChanged(advisor, oldState, newState)
-	}
 }
 
 // Clear removes all advisors from the pool

--- a/internal/advisor/pool_test.go
+++ b/internal/advisor/pool_test.go
@@ -420,20 +420,12 @@ func TestPool_Clear(t *testing.T) {
 
 // Mock listener for testing
 type mockListener struct {
-	mu           sync.Mutex
-	added        []*Advisor
-	removed      []string
-	insights     []*Insight
-	stateChanges []stateChange
+	mu      sync.Mutex
+	added   []*Advisor
+	removed []string
 	// Channels for synchronization in tests
 	addedCh   chan *Advisor
 	removedCh chan string
-}
-
-type stateChange struct {
-	advisor  *Advisor
-	oldState AdvisorState
-	newState AdvisorState
 }
 
 func newMockListener() *mockListener {
@@ -463,18 +455,6 @@ func (m *mockListener) OnAdvisorRemoved(advisorID string) {
 	case m.removedCh <- advisorID:
 	default:
 	}
-}
-
-func (m *mockListener) OnInsightGenerated(insight *Insight) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.insights = append(m.insights, insight)
-}
-
-func (m *mockListener) OnAdvisorStateChanged(advisor *Advisor, oldState, newState AdvisorState) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.stateChanges = append(m.stateChanges, stateChange{advisor, oldState, newState})
 }
 
 func TestPool_Listener_OnAdvisorAdded(t *testing.T) {

--- a/internal/belt/belt.go
+++ b/internal/belt/belt.go
@@ -29,8 +29,7 @@ type Renderer struct {
 	circularColor    color.RGBA
 
 	// Animation state
-	startTime  time.Time
-	frameCount int64 // Frame counter to avoid floating-point precision issues
+	startTime time.Time
 
 	// Rendering parameters
 	minWidth    float32 // Minimum belt width

--- a/internal/build/adapter.go
+++ b/internal/build/adapter.go
@@ -104,9 +104,6 @@ type BuildOptions struct {
 	// Zero means use adapter's default timeout.
 	Timeout time.Duration
 
-	// Verbose enables detailed output capture
-	Verbose bool
-
 	// Clean forces a clean build (no cache)
 	Clean bool
 

--- a/internal/build/adapter_test.go
+++ b/internal/build/adapter_test.go
@@ -276,9 +276,6 @@ func TestBuildOptions(t *testing.T) {
 	if opts.Timeout != 0 {
 		t.Errorf("default Timeout should be 0, got %v", opts.Timeout)
 	}
-	if opts.Verbose {
-		t.Error("default Verbose should be false, got true")
-	}
 	if opts.Clean {
 		t.Error("default Clean should be false, got true")
 	}
@@ -288,15 +285,11 @@ func TestBuildOptions(t *testing.T) {
 
 	// Test setting values
 	opts.Timeout = 5 * time.Minute
-	opts.Verbose = true
 	opts.Clean = true
 	opts.Jobs = 4
 
 	if opts.Timeout != 5*time.Minute {
 		t.Errorf("Timeout = %v, want 5m", opts.Timeout)
-	}
-	if !opts.Verbose {
-		t.Error("Verbose should be true")
 	}
 	if !opts.Clean {
 		t.Error("Clean should be true")

--- a/internal/build/bazel_test.go
+++ b/internal/build/bazel_test.go
@@ -432,9 +432,6 @@ func TestBuildOptions_Defaults(t *testing.T) {
 	if opts.Timeout != 0 {
 		t.Errorf("default Timeout = %v, want 0", opts.Timeout)
 	}
-	if opts.Verbose {
-		t.Error("default Verbose = true, want false")
-	}
 	if opts.Clean {
 		t.Error("default Clean = true, want false")
 	}

--- a/internal/build/integration_test.go
+++ b/internal/build/integration_test.go
@@ -45,7 +45,6 @@ func TestIntegration_BazelWorkflow(t *testing.T) {
 	// 3. Build should also fail gracefully without bazel
 	opts := &BuildOptions{
 		Timeout: 5 * time.Second,
-		Verbose: true,
 	}
 	_, err = adapter.Build(tmpDir, "//test:target", opts)
 	if err == nil {

--- a/internal/building/building.go
+++ b/internal/building/building.go
@@ -34,9 +34,8 @@ type Building struct {
 	y float64
 
 	// State
-	state      BuildState
-	lastBuild  *build.Result
-	buildQueue []BuildRequest
+	state     BuildState
+	lastBuild *build.Result
 
 	// Metrics (historical)
 	buildHistory []BuildRecord
@@ -52,12 +51,6 @@ const (
 	StateSuccess  BuildState = "success"  // Last build succeeded
 	StateFailed   BuildState = "failed"   // Last build failed
 )
-
-// BuildRequest represents a queued build operation
-type BuildRequest struct {
-	Options   *build.BuildOptions
-	Timestamp time.Time
-}
 
 // BuildRecord stores historical build information
 type BuildRecord struct {
@@ -124,7 +117,6 @@ func New(target build.Target, buildSystem string, x, y float64) *Building {
 		y:            y,
 		state:        StateIdle,
 		buildHistory: make([]BuildRecord, 0),
-		buildQueue:   make([]BuildRequest, 0),
 		metrics: Metrics{
 			MinDuration: time.Duration(1<<63 - 1), // Max int64
 		},

--- a/internal/connection/graph.go
+++ b/internal/connection/graph.go
@@ -24,7 +24,6 @@ type Graph struct {
 
 	// Cached analysis results
 	circularPaths [][]string // Detected circular dependency chains
-	analysisValid bool       // Whether cached analysis is current
 }
 
 // NewGraph creates an empty dependency graph.
@@ -54,7 +53,6 @@ func (g *Graph) Add(c *Connection) *Connection {
 	g.connections[id] = c
 	g.byFrom[c.from] = append(g.byFrom[c.from], c)
 	g.byTo[c.to] = append(g.byTo[c.to], c)
-	g.analysisValid = false
 
 	return c
 }
@@ -93,7 +91,6 @@ func (g *Graph) Remove(id string) bool {
 	delete(g.connections, id)
 	g.removeFromIndex(g.byFrom, c.from, c)
 	g.removeFromIndex(g.byTo, c.to, c)
-	g.analysisValid = false
 
 	return true
 }
@@ -126,7 +123,6 @@ func (g *Graph) Clear() {
 	g.byFrom = make(map[string][]*Connection)
 	g.byTo = make(map[string][]*Connection)
 	g.circularPaths = nil
-	g.analysisValid = false
 }
 
 // Count returns the number of connections in the graph.
@@ -254,7 +250,6 @@ func (g *Graph) DetectCircular() [][]string {
 	}
 
 	g.circularPaths = circularPaths
-	g.analysisValid = true
 	return circularPaths
 }
 


### PR DESCRIPTION
## Summary
- remove unused belt/graph/building fields
- drop unused BuildOptions.Verbose and related tests
- trim unused advisor pool listener hooks

## Testing
- nix develop --command bazel build //...
- xvfb-run -a -s '-screen 0 1024x768x24 -ac' nix develop --command bazel test //... (fails: race_verification_test expects --@io_bazel_rules_go//go/config:race)
- xvfb-run -a -s '-screen 0 1024x768x24 -ac' nix develop --command bazel test --@io_bazel_rules_go//go/config:race //... (fails: claude_integration_test; CLI needs --verbose with --print)