### PR TITLE
P2.1: Fix data races in watchers

### DIFF
--- a/internal/capability/watcher.go
+++ b/internal/capability/watcher.go
@@ -22,7 +22,8 @@ type Watcher struct {
 	wg           sync.WaitGroup
 
 	// File modification times for change detection
-	fileTimes map[string]time.Time
+	fileTimesMu sync.Mutex
+	fileTimes   map[string]time.Time
 }
 
 // NewWatcher creates a new watcher for the given registry.
@@ -117,10 +118,15 @@ func (w *Watcher) updateFileTimes() {
 		info, err := os.Stat(path)
 		if err != nil {
 			// File doesn't exist or can't be accessed
+			w.fileTimesMu.Lock()
 			delete(w.fileTimes, path)
+			w.fileTimesMu.Unlock()
 			continue
 		}
-		w.fileTimes[path] = info.ModTime()
+		modTime := info.ModTime()
+		w.fileTimesMu.Lock()
+		w.fileTimes[path] = modTime
+		w.fileTimesMu.Unlock()
 	}
 }
 
@@ -137,25 +143,30 @@ func (w *Watcher) checkForChanges() bool {
 	}
 
 	// Clean up paths no longer being watched (prevents memory leak)
+	w.fileTimesMu.Lock()
 	for path := range w.fileTimes {
 		if !currentPaths[path] {
 			delete(w.fileTimes, path)
 		}
 	}
+	w.fileTimesMu.Unlock()
 
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil {
 			// File doesn't exist now
+			w.fileTimesMu.Lock()
 			if _, existed := w.fileTimes[path]; existed {
 				// File was deleted
 				delete(w.fileTimes, path)
 				changed = true
 			}
+			w.fileTimesMu.Unlock()
 			continue
 		}
 
 		modTime := info.ModTime()
+		w.fileTimesMu.Lock()
 		if prevTime, exists := w.fileTimes[path]; exists {
 			if !modTime.Equal(prevTime) {
 				// File was modified
@@ -167,6 +178,7 @@ func (w *Watcher) checkForChanges() bool {
 			w.fileTimes[path] = modTime
 			changed = true
 		}
+		w.fileTimesMu.Unlock()
 	}
 
 	return changed

--- a/internal/debug/event.go
+++ b/internal/debug/event.go
@@ -1,6 +1,9 @@
 package debug
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // EventType represents the type of debug event.
 type EventType int
@@ -108,6 +111,7 @@ type EventHandler func(*Event)
 
 // EventBus manages debug event distribution.
 type EventBus struct {
+	mu       sync.RWMutex
 	handlers []EventHandler
 }
 
@@ -120,12 +124,18 @@ func NewEventBus() *EventBus {
 
 // Subscribe adds an event handler.
 func (bus *EventBus) Subscribe(handler EventHandler) {
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
 	bus.handlers = append(bus.handlers, handler)
 }
 
 // Publish sends an event to all handlers.
 func (bus *EventBus) Publish(event *Event) {
-	for _, h := range bus.handlers {
+	bus.mu.RLock()
+	handlers := append([]EventHandler(nil), bus.handlers...)
+	bus.mu.RUnlock()
+
+	for _, h := range handlers {
 		h(event)
 	}
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -125,11 +125,15 @@ func (b *BaseHarness) Name() string {
 
 // Version returns the harness version
 func (b *BaseHarness) Version() string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return b.version
 }
 
 // SetVersion sets the harness version
 func (b *BaseHarness) SetVersion(version string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.version = version
 }
 

--- a/internal/production/watcher.go
+++ b/internal/production/watcher.go
@@ -28,7 +28,8 @@ type Watcher struct {
 	wg           sync.WaitGroup
 
 	// File modification times for change detection
-	fileTimes map[string]time.Time
+	fileTimesMu sync.Mutex
+	fileTimes   map[string]time.Time
 }
 
 // NewWatcher creates a new watcher for the given registry.
@@ -123,10 +124,15 @@ func (w *Watcher) updateFileTimes() {
 		info, err := os.Stat(path)
 		if err != nil {
 			// File doesn't exist or can't be accessed
+			w.fileTimesMu.Lock()
 			delete(w.fileTimes, path)
+			w.fileTimesMu.Unlock()
 			continue
 		}
-		w.fileTimes[path] = info.ModTime()
+		modTime := info.ModTime()
+		w.fileTimesMu.Lock()
+		w.fileTimes[path] = modTime
+		w.fileTimesMu.Unlock()
 	}
 }
 
@@ -143,25 +149,30 @@ func (w *Watcher) checkForChanges() bool {
 	}
 
 	// Clean up paths no longer being watched (prevents memory leak)
+	w.fileTimesMu.Lock()
 	for path := range w.fileTimes {
 		if !currentPaths[path] {
 			delete(w.fileTimes, path)
 		}
 	}
+	w.fileTimesMu.Unlock()
 
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil {
 			// File doesn't exist now
+			w.fileTimesMu.Lock()
 			if _, existed := w.fileTimes[path]; existed {
 				// File was deleted
 				delete(w.fileTimes, path)
 				changed = true
 			}
+			w.fileTimesMu.Unlock()
 			continue
 		}
 
 		modTime := info.ModTime()
+		w.fileTimesMu.Lock()
 		if prevTime, exists := w.fileTimes[path]; exists {
 			if !modTime.Equal(prevTime) {
 				// File was modified
@@ -173,6 +184,7 @@ func (w *Watcher) checkForChanges() bool {
 			w.fileTimes[path] = modTime
 			changed = true
 		}
+		w.fileTimesMu.Unlock()
 	}
 
 	return changed


### PR DESCRIPTION
## Summary\n- guard watcher fileTimes with a mutex in capability and production\n- lock BaseHarness version access\n- make debug EventBus thread-safe\n\n## Testing\n- nix develop --command bazel build //...\n- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test //... (fails: race_verification_test expects race flag)\n- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...