### PR TITLE
P2.2: Add channel safety and close guards

### DIFF
--- a/internal/claude/interceptor.go
+++ b/internal/claude/interceptor.go
@@ -45,11 +45,13 @@ type EventHandler func(*Event)
 
 // Interceptor intercepts Claude Code tool calls via JSON output
 type Interceptor struct {
-	mu       sync.RWMutex
-	cmd      *exec.Cmd
-	handlers []EventHandler
-	running  bool
-	events   chan *Event
+	mu        sync.RWMutex
+	cmd       *exec.Cmd
+	handlers  []EventHandler
+	running   bool
+	events    chan *Event
+	closeOnce sync.Once
+	closed    bool
 }
 
 // New creates a new Claude interceptor
@@ -67,6 +69,28 @@ func (i *Interceptor) AddHandler(handler EventHandler) {
 	i.handlers = append(i.handlers, handler)
 }
 
+func (i *Interceptor) isClosed() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.closed
+}
+
+func (i *Interceptor) closeEvents() {
+	i.closeOnce.Do(func() {
+		i.mu.Lock()
+		defer i.mu.Unlock()
+		i.closed = true
+		close(i.events)
+	})
+}
+
+func (i *Interceptor) emitEvent(event *Event) {
+	if event == nil || i.isClosed() {
+		return
+	}
+	i.events <- event
+}
+
 // Start begins intercepting Claude output
 // For now, this is a stub that will be connected to actual Claude subprocess
 func (i *Interceptor) Start() error {
@@ -74,6 +98,10 @@ func (i *Interceptor) Start() error {
 	if i.running {
 		i.mu.Unlock()
 		return fmt.Errorf("interceptor already running")
+	}
+	if i.closed {
+		i.mu.Unlock()
+		return fmt.Errorf("interceptor is closed")
 	}
 	i.running = true
 	i.mu.Unlock()
@@ -99,17 +127,20 @@ func (i *Interceptor) Start() error {
 // Stop stops the interceptor
 func (i *Interceptor) Stop() error {
 	i.mu.Lock()
-	defer i.mu.Unlock()
 
 	if !i.running {
+		i.mu.Unlock()
 		return nil
 	}
 
 	i.running = false
-	close(i.events)
+	cmd := i.cmd
+	i.mu.Unlock()
 
-	if i.cmd != nil && i.cmd.Process != nil {
-		return i.cmd.Process.Kill()
+	i.closeEvents()
+
+	if cmd != nil && cmd.Process != nil {
+		return cmd.Process.Kill()
 	}
 
 	return nil
@@ -145,7 +176,7 @@ func (i *Interceptor) parseOutput(reader io.Reader) {
 		// Determine event type and create event
 		event := i.parseEvent(data)
 		if event != nil {
-			i.events <- event
+			i.emitEvent(event)
 		}
 	}
 }
@@ -215,36 +246,36 @@ func containsAny(s string, substrs []string) bool {
 
 // SimulateFileRead simulates a file read event (for testing)
 func (i *Interceptor) SimulateFileRead(path string) {
-	i.events <- &Event{
+	i.emitEvent(&Event{
 		Type:      EventFileRead,
 		Timestamp: time.Now(),
 		Data: map[string]interface{}{
 			"tool":      "Read",
 			"file_path": path,
 		},
-	}
+	})
 }
 
 // SimulateFileWrite simulates a file write event (for testing)
 func (i *Interceptor) SimulateFileWrite(path string) {
-	i.events <- &Event{
+	i.emitEvent(&Event{
 		Type:      EventFileWrite,
 		Timestamp: time.Now(),
 		Data: map[string]interface{}{
 			"tool":      "Write",
 			"file_path": path,
 		},
-	}
+	})
 }
 
 // SimulateFileEdit simulates a file edit event (for testing)
 func (i *Interceptor) SimulateFileEdit(path string) {
-	i.events <- &Event{
+	i.emitEvent(&Event{
 		Type:      EventFileEdit,
 		Timestamp: time.Now(),
 		Data: map[string]interface{}{
 			"tool":      "Edit",
 			"file_path": path,
 		},
-	}
+	})
 }

--- a/internal/harness/claude/claude.go
+++ b/internal/harness/claude/claude.go
@@ -124,6 +124,7 @@ func (c *ClaudeHarness) Start(ctx context.Context, config harness.Config) error 
 
 	// Create parser and start reading output
 	c.parser = NewParser(c.EventsWritable())
+	c.parser.SetClosedFunc(c.EventsClosed)
 	c.wg.Add(2)
 	go c.readOutput()
 	go c.readErrors()

--- a/internal/harness/claude/parser.go
+++ b/internal/harness/claude/parser.go
@@ -13,6 +13,7 @@ import (
 // Parser parses Claude Code JSON output and emits harness events
 type Parser struct {
 	events chan<- harness.Event
+	closed func() bool
 	// DebugWriter, if set, receives debug output for parse failures and
 	// unrecognized event types. Useful for troubleshooting Claude output changes.
 	DebugWriter io.Writer
@@ -28,6 +29,11 @@ func NewParser(events chan<- harness.Event) *Parser {
 	}
 }
 
+// SetClosedFunc sets a function used to detect whether the events channel is closed.
+func (p *Parser) SetClosedFunc(fn func() bool) {
+	p.closed = fn
+}
+
 // SetDebugWriter sets the writer for debug output.
 // Pass nil to disable debug logging.
 func (p *Parser) SetDebugWriter(w io.Writer) {
@@ -41,23 +47,37 @@ func (p *Parser) debugf(format string, args ...interface{}) {
 	}
 }
 
+func (p *Parser) isClosed() bool {
+	if p.closed == nil {
+		return false
+	}
+	return p.closed()
+}
+
+func (p *Parser) emit(event harness.Event) {
+	if p.isClosed() {
+		return
+	}
+	p.events <- event
+}
+
 // ParseLine parses a single line of JSON output
 func (p *Parser) ParseLine(line []byte) {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(line, &raw); err != nil {
 		p.debugf("JSON parse error: %v (line: %s)", err, string(line))
 		if p.EmitParseWarnings {
-			p.events <- harness.NewEvent(harness.EventWarning).
+			p.emit(harness.NewEvent(harness.EventWarning).
 				WithText(fmt.Sprintf("Failed to parse JSON: %s", string(line))).
 				WithSource("claude-code-parser").
-				Build()
+				Build())
 		}
 		return
 	}
 
 	event := p.parseEvent(raw)
 	if event != nil {
-		p.events <- *event
+		p.emit(*event)
 	} else {
 		p.debugf("unrecognized event structure: %s", string(line))
 	}
@@ -421,7 +441,7 @@ func (p *Parser) ParseJSON(data []byte) error {
 
 	event := p.parseEvent(raw)
 	if event != nil {
-		p.events <- *event
+		p.emit(*event)
 	}
 	return nil
 }
@@ -436,7 +456,7 @@ func (p *Parser) ParseToolUse(toolName string, input map[string]interface{}) {
 		WithSource("claude-code").
 		Build()
 
-	p.events <- event
+	p.emit(event)
 }
 
 // ParseToolResult creates a tool result event
@@ -449,5 +469,5 @@ func (p *Parser) ParseToolResult(toolName string, output map[string]interface{})
 		builder = builder.WithToolOutput(k, v)
 	}
 
-	p.events <- builder.Build()
+	p.emit(builder.Build())
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -84,8 +84,8 @@ type HarnessFactory func() Harness
 //   - EventsWritable() returns a send-only channel. Multiple goroutines may
 //     send events concurrently, but implementers must ensure the channel is
 //     not closed while sends are in progress.
-//   - CloseEvents() must be called exactly once, after all senders have stopped.
-//     Use sync.Once in implementations to prevent double-close panics.
+//   - CloseEvents() should be called after all senders have stopped. It is
+//     safe to call more than once.
 //
 // # Event Ordering
 //
@@ -103,11 +103,13 @@ type HarnessFactory func() Harness
 //
 // Once stopped, a BaseHarness cannot be restarted. Create a new instance instead.
 type BaseHarness struct {
-	mu      sync.RWMutex
-	name    string
-	version string
-	running bool
-	events  chan Event
+	mu        sync.RWMutex
+	name      string
+	version   string
+	running   bool
+	events    chan Event
+	closeOnce sync.Once
+	closed    bool
 }
 
 // NewBaseHarness creates a new base harness with the given name
@@ -157,7 +159,19 @@ func (b *BaseHarness) EventsWritable() chan<- Event {
 	return b.events
 }
 
+// EventsClosed reports whether the events channel has been closed.
+func (b *BaseHarness) EventsClosed() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.closed
+}
+
 // CloseEvents closes the events channel
 func (b *BaseHarness) CloseEvents() {
-	close(b.events)
+	b.closeOnce.Do(func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		b.closed = true
+		close(b.events)
+	})
 }

--- a/internal/harness/mock.go
+++ b/internal/harness/mock.go
@@ -129,6 +129,9 @@ func (m *MockHarness) StartConfig() Config {
 
 // SimulateEvent sends an event to consumers (for testing event handlers).
 func (m *MockHarness) SimulateEvent(event Event) {
+	if !m.IsRunning() || m.EventsClosed() {
+		return
+	}
 	m.EventsWritable() <- event
 }
 


### PR DESCRIPTION
## Summary\n- add close guards and closed state for interceptor and harness base\n- guard parser/mock sends when events are closed\n- wire parser closed checks in Claude harness\n\n## Testing\n- nix develop --command bazel build //...\n- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test //... (fails: race_verification_test requires race flag)\n- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...