### PR TITLE
P2.3: Fix goroutine leaks in multiagent

### DIFF
--- a/internal/multiagent/orchestrator.go
+++ b/internal/multiagent/orchestrator.go
@@ -1,6 +1,7 @@
 package multiagent
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -14,13 +15,13 @@ import (
 // but we won't block waiting for it).
 const listenerTimeout = 5 * time.Second
 
-// abandonedListenerCount tracks the number of listener notifications that timed out.
+// abandonedListenerCount tracks the number of listener callbacks that timed out.
 // This counter is useful for debugging listener performance issues. When a listener
 // callback takes longer than listenerTimeout, the orchestrator stops waiting but
-// the goroutine may still be running in the background.
+// the goroutine may still be running in the background if the listener ignores ctx.
 var abandonedListenerCount int64
 
-// AbandonedListenerCount returns the number of listener notifications that have
+// AbandonedListenerCount returns the number of listener callbacks that have
 // timed out. This is useful for debugging listener performance issues and detecting
 // potential goroutine leaks from slow or stuck listeners.
 func AbandonedListenerCount() int64 {
@@ -32,7 +33,9 @@ type OrchestratorListener interface {
 	// OnAgentsChanged is called when agents are added, removed, or updated.
 	// The provided slice is read-only and must not be modified.
 	// Listeners are called asynchronously in goroutines.
-	OnAgentsChanged(agents []*Agent)
+	// The context is canceled when the listener times out.
+	// Implementations should return promptly when ctx.Done() is closed.
+	OnAgentsChanged(ctx context.Context, agents []*Agent)
 }
 
 // Orchestrator manages multiple concurrent agents and their task assignments.
@@ -273,8 +276,17 @@ func (o *Orchestrator) RemoveListener(l OrchestratorListener) {
 
 // notifyListeners asynchronously notifies all listeners with timeout protection.
 // Each listener callback runs in its own goroutine with panic recovery.
-// Note: If a listener blocks longer than listenerTimeout, its goroutine is abandoned
-// but may continue running. Callers should ensure listeners are well-behaved.
+// Note: If a listener blocks longer than listenerTimeout, the timeout context is canceled.
+// Listeners must respect ctx.Done() to avoid lingering goroutines.
+//
+// Goroutines:
+// - listenerRunner: wraps each listener, enforces a per-listener timeout, exits on done/timeout.
+// - listenerCall: invokes listener.OnAgentsChanged with a timeout context and closes done when finished.
+//
+// Channel: done (chan struct{})
+// - Created by: listenerRunner
+// - Writers: listenerCall (close)
+// - Readers: listenerRunner (select)
 func (o *Orchestrator) notifyListeners(listeners []OrchestratorListener) {
 	if len(listeners) == 0 {
 		return
@@ -287,29 +299,30 @@ func (o *Orchestrator) notifyListeners(listeners []OrchestratorListener) {
 		wg.Add(1)
 		go func(listener OrchestratorListener) {
 			defer wg.Done()
-			defer func() {
-				if rec := recover(); rec != nil {
-					log.Printf("orchestrator: listener panic recovered: %v", rec)
-				}
+			ctx, cancel := context.WithTimeout(context.Background(), listenerTimeout)
+			defer cancel()
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				defer func() {
+					if rec := recover(); rec != nil {
+						log.Printf("orchestrator: listener panic recovered: %v", rec)
+					}
+				}()
+				listener.OnAgentsChanged(ctx, agents)
 			}()
-			listener.OnAgentsChanged(agents)
+
+			select {
+			case <-done:
+			case <-ctx.Done():
+				atomic.AddInt64(&abandonedListenerCount, 1)
+				log.Printf("orchestrator: listener notification timeout after %v", listenerTimeout)
+			}
 		}(l)
 	}
 
-	// Wait for listeners with timeout to prevent indefinite blocking
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// All listeners completed
-	case <-time.After(listenerTimeout):
-		atomic.AddInt64(&abandonedListenerCount, 1)
-		log.Printf("orchestrator: listener notification timeout after %v", listenerTimeout)
-	}
+	wg.Wait()
 }
 
 // GetSharedFiles returns files that have been read by multiple agents.

--- a/internal/multiagent/orchestrator_test.go
+++ b/internal/multiagent/orchestrator_test.go
@@ -1,6 +1,7 @@
 package multiagent
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -375,7 +376,7 @@ func TestOrchestratorListener(t *testing.T) {
 	done := make(chan struct{})
 
 	listener := &testListener{
-		onChanged: func(agents []*Agent) {
+		onChanged: func(_ context.Context, agents []*Agent) {
 			mu.Lock()
 			notifiedAgents = agents
 			mu.Unlock()
@@ -416,12 +417,12 @@ func TestOrchestratorRemoveListener(t *testing.T) {
 
 // testListener implements OrchestratorListener for testing.
 type testListener struct {
-	onChanged func([]*Agent)
+	onChanged func(context.Context, []*Agent)
 }
 
-func (l *testListener) OnAgentsChanged(agents []*Agent) {
+func (l *testListener) OnAgentsChanged(ctx context.Context, agents []*Agent) {
 	if l.onChanged != nil {
-		l.onChanged(agents)
+		l.onChanged(ctx, agents)
 	}
 }
 
@@ -563,14 +564,14 @@ func TestOrchestratorListenerPanicRecovery(t *testing.T) {
 
 	// Listener that panics
 	panicListener := &testListener{
-		onChanged: func(agents []*Agent) {
+		onChanged: func(_ context.Context, agents []*Agent) {
 			panic("intentional panic for testing")
 		},
 	}
 
 	// Listener that works normally
 	normalListener := &testListener{
-		onChanged: func(agents []*Agent) {
+		onChanged: func(_ context.Context, agents []*Agent) {
 			close(done)
 		},
 	}


### PR DESCRIPTION
## Summary
- add context-aware listener interface for per-listener timeouts
- avoid orphaned wait goroutines in orchestrator notifications
- update listener tests for context cancellation

## Testing
- nix develop --command bazel build //...
- nix develop --command bazel test //... (fails: DISPLAY missing in headless)
- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test //... (fails: race_verification_test expects race)
- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...