### PR TITLE
P2.4: Enforce harness lifecycle semantics

### DIFF
--- a/internal/game/scene.go
+++ b/internal/game/scene.go
@@ -276,11 +276,14 @@ func (gs *GameScene) handlePromptCancel() {
 // SetConfig sets the configuration from the start screen.
 // If a harness is specified, it will be started.
 func (gs *GameScene) SetConfig(config ui.GameConfig) {
+	gs.stopMainHarness()
 	gs.config = config
 
 	// Start the selected harness if one is specified
 	if config.Harness != "" && gs.registry.IsRegistered(config.Harness) {
 		gs.startHarness(config)
+	} else {
+		gs.onPromptSubmit = nil
 	}
 }
 
@@ -335,6 +338,27 @@ func (gs *GameScene) startHarness(config ui.GameConfig) {
 	// Start event processing goroutine
 	gs.harnessWg.Add(1)
 	go gs.processHarnessEvents()
+}
+
+// stopMainHarness stops the current harness and waits for its event processing to finish.
+func (gs *GameScene) stopMainHarness() {
+	if gs.mainHarness != nil {
+		if err := gs.mainHarness.Stop(); err != nil {
+			// Log but don't fail on harness stop error
+			_ = err
+		}
+	}
+	if gs.harnessStop != nil {
+		gs.harnessStop()
+	}
+
+	// Wait for event processing goroutine to complete
+	gs.harnessWg.Wait()
+
+	gs.mainHarness = nil
+	gs.harnessCtx = nil
+	gs.harnessStop = nil
+	gs.onPromptSubmit = nil
 }
 
 // processHarnessEvents reads events from the main harness and processes them.
@@ -677,19 +701,7 @@ func (gs *GameScene) Close() error {
 		gs.productionWatcher.Stop()
 	}
 
-	// Stop the main harness if running
-	if gs.mainHarness != nil {
-		if err := gs.mainHarness.Stop(); err != nil {
-			// Log but don't fail on harness stop error
-			_ = err
-		}
-	}
-	if gs.harnessStop != nil {
-		gs.harnessStop()
-	}
-
-	// Wait for event processing goroutine to complete
-	gs.harnessWg.Wait()
+	gs.stopMainHarness()
 
 	// Stop legacy interceptor
 	if gs.interceptor != nil {

--- a/internal/harness/claude/claude.go
+++ b/internal/harness/claude/claude.go
@@ -57,6 +57,9 @@ func (c *ClaudeHarness) Start(ctx context.Context, config harness.Config) error 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if c.IsStopped() {
+		return fmt.Errorf("harness already stopped")
+	}
 	if c.IsRunning() {
 		return fmt.Errorf("harness already running")
 	}
@@ -310,6 +313,10 @@ func (c *ClaudeHarness) Stop() error {
 	defer c.mu.Unlock()
 
 	if !c.IsRunning() {
+		c.SetRunning(false)
+		c.closeOnce.Do(func() {
+			c.CloseEvents()
+		})
 		return nil
 	}
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -107,6 +107,7 @@ type BaseHarness struct {
 	name      string
 	version   string
 	running   bool
+	stopped   bool
 	events    chan Event
 	closeOnce sync.Once
 	closed    bool
@@ -146,11 +147,28 @@ func (b *BaseHarness) IsRunning() bool {
 	return b.running
 }
 
-// SetRunning sets the running state
+// IsStopped returns whether the harness has been stopped.
+// Once stopped, a harness cannot be restarted.
+func (b *BaseHarness) IsStopped() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.stopped
+}
+
+// SetRunning sets the running state.
+// Setting running to false marks the harness as stopped.
 func (b *BaseHarness) SetRunning(running bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.running = running
+	if running {
+		if b.stopped {
+			return
+		}
+		b.running = true
+		return
+	}
+	b.running = false
+	b.stopped = true
 }
 
 // Events returns the events channel

--- a/internal/harness/lifecycle_test.go
+++ b/internal/harness/lifecycle_test.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +28,9 @@ func NewTestableHarness() *TestableHarness {
 func (t *TestableHarness) Start(ctx context.Context, config Config) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.IsStopped() {
+		return fmt.Errorf("test harness already stopped")
+	}
 	t.startCalled = true
 	t.SetRunning(true)
 	return nil
@@ -166,6 +170,22 @@ collectLoop:
 	}
 	if h.IsRunning() {
 		t.Error("Should not be running after Stop()")
+	}
+}
+
+func TestLifecycleRestartAfterStopFails(t *testing.T) {
+	h := NewTestableHarness()
+
+	config := NewConfig("/tmp")
+	if err := h.Start(context.Background(), config); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := h.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	if err := h.Start(context.Background(), config); err == nil {
+		t.Fatal("Start() should fail after Stop()")
 	}
 }
 

--- a/internal/harness/mock.go
+++ b/internal/harness/mock.go
@@ -11,10 +11,11 @@ import (
 type MockHarness struct {
 	*BaseHarness
 
-	mu      sync.Mutex
-	prompts []string // All prompts sent via SendPrompt
-	started bool
-	config  Config
+	mu        sync.Mutex
+	prompts   []string // All prompts sent via SendPrompt
+	started   bool
+	config    Config
+	closeOnce sync.Once
 }
 
 // NewMockHarness creates a new mock harness for testing.
@@ -30,6 +31,9 @@ func (m *MockHarness) Start(ctx context.Context, config Config) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if m.IsStopped() {
+		return fmt.Errorf("mock harness already stopped")
+	}
 	if m.started {
 		return fmt.Errorf("mock harness already started")
 	}
@@ -49,13 +53,15 @@ func (m *MockHarness) Stop() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !m.started {
+	if m.IsStopped() {
 		return nil
 	}
 
 	m.started = false
 	m.SetRunning(false)
-	m.CloseEvents()
+	m.closeOnce.Do(func() {
+		m.CloseEvents()
+	})
 	return nil
 }
 

--- a/internal/harness/mock_test.go
+++ b/internal/harness/mock_test.go
@@ -48,6 +48,10 @@ func TestMockHarness_SendPrompt(t *testing.T) {
 	if err := mock.SendPrompt("should fail"); err == nil {
 		t.Error("SendPrompt should fail after Stop")
 	}
+
+	if err := mock.Start(context.Background(), config); err == nil {
+		t.Error("Start should fail after Stop")
+	}
 }
 
 func TestMockHarness_SimulateEvents(t *testing.T) {

--- a/internal/harness/registry_test.go
+++ b/internal/harness/registry_test.go
@@ -256,6 +256,9 @@ func TestBaseHarness(t *testing.T) {
 	if b.IsRunning() {
 		t.Error("IsRunning() should be false initially")
 	}
+	if b.IsStopped() {
+		t.Error("IsStopped() should be false initially")
+	}
 
 	b.SetVersion("1.0.0")
 	if b.Version() != "1.0.0" {
@@ -265,6 +268,19 @@ func TestBaseHarness(t *testing.T) {
 	b.SetRunning(true)
 	if !b.IsRunning() {
 		t.Error("IsRunning() should be true after SetRunning(true)")
+	}
+
+	b.SetRunning(false)
+	if b.IsRunning() {
+		t.Error("IsRunning() should be false after SetRunning(false)")
+	}
+	if !b.IsStopped() {
+		t.Error("IsStopped() should be true after SetRunning(false)")
+	}
+
+	b.SetRunning(true)
+	if b.IsRunning() {
+		t.Error("IsRunning() should remain false after stop")
 	}
 }
 


### PR DESCRIPTION
## Summary
- enforce single-use harness lifecycle (no Start after Stop)
- stop existing harness before applying new GameScene config
- add tests to lock restart behavior

## Testing
- nix develop --command bazel build //...
- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...
- nix develop --command go fmt ./...