### PR TITLE
P3.2: Split headless vs display tests

### DIFF
--- a/internal/input/mode_test.go
+++ b/internal/input/mode_test.go
@@ -1,19 +1,6 @@
 package input
 
-import (
-	"os"
-	"testing"
-)
-
-// TestMain sets up the test environment
-func TestMain(m *testing.M) {
-	// If no display is available, skip all tests in this package
-	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
-		println("Skipping input tests: no display available (DISPLAY and WAYLAND_DISPLAY not set)")
-		os.Exit(0)
-	}
-	os.Exit(m.Run())
-}
+import "testing"
 
 func TestMode_String(t *testing.T) {
 	tests := []struct {

--- a/internal/systemtest/main_test.go
+++ b/internal/systemtest/main_test.go
@@ -12,7 +12,6 @@
 package systemtest
 
 import (
-	"os"
 	"testing"
 
 	"github.com/tedks/CodingGame/internal/input"
@@ -20,23 +19,9 @@ import (
 	"github.com/tedks/CodingGame/internal/ui"
 )
 
-// hasDisplay checks if a display is available for running graphical tests.
-func hasDisplay() bool {
-	return os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != ""
-}
-
-// skipIfNoDisplay skips the test if no display is available.
-func skipIfNoDisplay(t *testing.T) {
-	if !hasDisplay() {
-		t.Skip("Skipping: no display available (set DISPLAY or WAYLAND_DISPLAY)")
-	}
-}
-
 // TestSystemTests is the single entry point for all system tests.
 // All tests run as subtests to avoid GLFW re-initialization issues.
 func TestSystemTests(t *testing.T) {
-	skipIfNoDisplay(t)
-
 	// Navigation tests
 	t.Run("Navigation", func(t *testing.T) {
 		t.Run("HKeyPansLeft", testNavigationHKeyPansLeft)

--- a/internal/testutil/BUILD.bazel
+++ b/internal/testutil/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "compare_test.go",
         "input_test.go",
         "race_test.go",
+        "runner_display_test.go",
         "runner_test.go",
         "scenario_test.go",
         "screenshot_test.go",

--- a/internal/testutil/runner_display_test.go
+++ b/internal/testutil/runner_display_test.go
@@ -1,0 +1,87 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func requireDisplay(t *testing.T) {
+	t.Helper()
+	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+		t.Skip("Skipping: no display available (set DISPLAY or WAYLAND_DISPLAY)")
+	}
+}
+
+// Integration tests that require a running game are below.
+// These use a single test to avoid GLFW reinitialization issues.
+func TestRunAndCaptureIntegration(t *testing.T) {
+	requireDisplay(t)
+
+	// Skip in short mode
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Create a simple game that draws a colored background
+	drawCalled := false
+	game := NewSimpleTestGame(100, 100, func(screen *ebiten.Image) {
+		drawCalled = true
+		// Just clear screen - don't need to fill with color for this test
+	})
+
+	// Run for a few frames and capture
+	screenshot, err := RunAndCapture(game, 3, 100, 100)
+
+	// Note: This test may fail if GLFW was already initialized in another test.
+	// That's expected - run this test in isolation if needed.
+	if err != nil {
+		// Check if it's a GLFW error - if so, skip gracefully
+		if isGLFWError(err) {
+			t.Skipf("Skipping: GLFW initialization issue (expected if other tests ran first): %v", err)
+		}
+		t.Fatalf("RunAndCapture() error: %v", err)
+	}
+
+	if !drawCalled {
+		t.Error("Draw function was not called")
+	}
+
+	if screenshot == nil {
+		t.Fatal("Screenshot is nil")
+	}
+
+	// Verify dimensions
+	if screenshot.Width() != 100 || screenshot.Height() != 100 {
+		t.Errorf("Screenshot dimensions = (%d, %d), want (100, 100)",
+			screenshot.Width(), screenshot.Height())
+	}
+
+	// Verify we can get the underlying image
+	if screenshot.Image() == nil {
+		t.Error("Screenshot.Image() returned nil")
+	}
+}
+
+// isGLFWError checks if an error is related to GLFW initialization.
+func isGLFWError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return contains(errStr, "glfw") || contains(errStr, "GLFW")
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr, 0))
+}
+
+func containsAt(s, substr string, start int) bool {
+	for i := start; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/testutil/runner_test.go
+++ b/internal/testutil/runner_test.go
@@ -1,20 +1,6 @@
 package testutil
 
-import (
-	"os"
-	"testing"
-
-	"github.com/hajimehoshi/ebiten/v2"
-)
-
-func TestMain(m *testing.M) {
-	// Skip tests if no display is available
-	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
-		println("Skipping testutil tests: no display available")
-		os.Exit(0)
-	}
-	os.Exit(m.Run())
-}
+import "testing"
 
 // TestTestGameFrameCount tests the frame counter without running the full game.
 func TestTestGameFrameCount(t *testing.T) {
@@ -78,77 +64,4 @@ func TestNewTestGame(t *testing.T) {
 	if testGame.FrameCount() != 0 {
 		t.Errorf("FrameCount() = %d, want 0", testGame.FrameCount())
 	}
-}
-
-// Integration tests that require a running game are below.
-// These use a single test to avoid GLFW reinitialization issues.
-
-// TestRunAndCaptureIntegration is an integration test that runs the full game loop.
-// It's structured as a single test to work around GLFW's one-init-per-process limitation.
-func TestRunAndCaptureIntegration(t *testing.T) {
-	// Skip in short mode
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	// Create a simple game that draws a colored background
-	drawCalled := false
-	game := NewSimpleTestGame(100, 100, func(screen *ebiten.Image) {
-		drawCalled = true
-		// Just clear screen - don't need to fill with color for this test
-	})
-
-	// Run for a few frames and capture
-	screenshot, err := RunAndCapture(game, 3, 100, 100)
-
-	// Note: This test may fail if GLFW was already initialized in another test.
-	// That's expected - run this test in isolation if needed.
-	if err != nil {
-		// Check if it's a GLFW error - if so, skip gracefully
-		if isGLFWError(err) {
-			t.Skipf("Skipping: GLFW initialization issue (expected if other tests ran first): %v", err)
-		}
-		t.Fatalf("RunAndCapture() error: %v", err)
-	}
-
-	if !drawCalled {
-		t.Error("Draw function was not called")
-	}
-
-	if screenshot == nil {
-		t.Fatal("Screenshot is nil")
-	}
-
-	// Verify dimensions
-	if screenshot.Width() != 100 || screenshot.Height() != 100 {
-		t.Errorf("Screenshot dimensions = (%d, %d), want (100, 100)",
-			screenshot.Width(), screenshot.Height())
-	}
-
-	// Verify we can get the underlying image
-	if screenshot.Image() == nil {
-		t.Error("Screenshot.Image() returned nil")
-	}
-}
-
-// isGLFWError checks if an error is related to GLFW initialization.
-func isGLFWError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return contains(errStr, "glfw") || contains(errStr, "GLFW")
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr, 0))
-}
-
-func containsAt(s, substr string, start int) bool {
-	for i := start; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/ui/scene_test.go
+++ b/internal/ui/scene_test.go
@@ -1,20 +1,6 @@
 package ui
 
-import (
-	"os"
-	"testing"
-)
-
-// TestMain sets up the test environment
-func TestMain(m *testing.M) {
-	// If no display is available, skip all tests in this package
-	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
-		// Print skip message and exit successfully
-		println("Skipping ui tests: no display available (DISPLAY and WAYLAND_DISPLAY not set)")
-		os.Exit(0)
-	}
-	os.Exit(m.Run())
-}
+import "testing"
 
 func TestSceneManagerBasics(t *testing.T) {
 	// Test NewSceneManager with nil


### PR DESCRIPTION
## Summary
- remove package-wide display skips so headless-safe tests run without DISPLAY
- move RunAndCapture integration test into display-only file with explicit display guard
- keep testutil BUILD target updated for the new display test file

## Testing
- nix develop --command go fmt ./...
- nix develop --command bazel build //...
- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...