### PR TITLE
P4.1: Fix MinDuration sentinel values

### DIFF
--- a/internal/advisor/advisor.go
+++ b/internal/advisor/advisor.go
@@ -50,7 +50,7 @@ type AdvisorMetrics struct {
 	InsightCount int
 	CancelCount  int
 
-	// Timing statistics
+	// Timing statistics (zero when TotalRuns == 0)
 	TotalDuration time.Duration
 	AvgDuration   time.Duration
 	MinDuration   time.Duration
@@ -81,9 +81,6 @@ func New(config Config, x, y float64) *Advisor {
 		insights: make([]*Insight, 0),
 		x:        x,
 		y:        y,
-		metrics: AdvisorMetrics{
-			MinDuration: time.Duration(1<<63 - 1), // Max int64
-		},
 	}
 }
 
@@ -230,11 +227,16 @@ func (a *Advisor) CompleteAnalysis(duration time.Duration, tokensIn, tokensOut i
 	a.metrics.TotalTokensOut += tokensOut
 
 	// Update min/max
-	if duration < a.metrics.MinDuration {
+	if a.metrics.TotalRuns == 1 {
 		a.metrics.MinDuration = duration
-	}
-	if duration > a.metrics.MaxDuration {
 		a.metrics.MaxDuration = duration
+	} else {
+		if duration < a.metrics.MinDuration {
+			a.metrics.MinDuration = duration
+		}
+		if duration > a.metrics.MaxDuration {
+			a.metrics.MaxDuration = duration
+		}
 	}
 
 	// Update average

--- a/internal/advisor/advisor_test.go
+++ b/internal/advisor/advisor_test.go
@@ -476,6 +476,32 @@ func TestAdvisor_AcceptanceRate(t *testing.T) {
 	}
 }
 
+func TestAdvisorMetrics_ZeroValues(t *testing.T) {
+	metrics := AdvisorMetrics{}
+
+	if metrics.TotalRuns != 0 {
+		t.Errorf("TotalRuns zero value = %d, want 0", metrics.TotalRuns)
+	}
+	if metrics.TotalTokensIn != 0 {
+		t.Errorf("TotalTokensIn zero value = %d, want 0", metrics.TotalTokensIn)
+	}
+	if metrics.TotalTokensOut != 0 {
+		t.Errorf("TotalTokensOut zero value = %d, want 0", metrics.TotalTokensOut)
+	}
+	if metrics.MinDuration != 0 {
+		t.Errorf("MinDuration zero value = %v, want 0", metrics.MinDuration)
+	}
+	if metrics.MaxDuration != 0 {
+		t.Errorf("MaxDuration zero value = %v, want 0", metrics.MaxDuration)
+	}
+	if metrics.AvgDuration != 0 {
+		t.Errorf("AvgDuration zero value = %v, want 0", metrics.AvgDuration)
+	}
+	if metrics.LastDuration != 0 {
+		t.Errorf("LastDuration zero value = %v, want 0", metrics.LastDuration)
+	}
+}
+
 func TestAdvisor_Metrics_MultipleRuns(t *testing.T) {
 	a := New(Config{ID: "test", Name: "Test", SystemPrompt: "test", Trigger: TriggerManual}, 0, 0)
 

--- a/internal/building/building.go
+++ b/internal/building/building.go
@@ -69,7 +69,7 @@ type Metrics struct {
 	SuccessCount int
 	FailureCount int
 
-	// Timing statistics
+	// Timing statistics (zero when TotalBuilds == 0)
 	AvgDuration  time.Duration
 	MinDuration  time.Duration
 	MaxDuration  time.Duration
@@ -117,9 +117,6 @@ func New(target build.Target, buildSystem string, x, y float64) *Building {
 		y:            y,
 		state:        StateIdle,
 		buildHistory: make([]BuildRecord, 0),
-		metrics: Metrics{
-			MinDuration: time.Duration(1<<63 - 1), // Max int64
-		},
 	}
 }
 
@@ -250,8 +247,8 @@ func (b *Building) updateMetrics() {
 	var totalCacheHits int64
 	var successCount int
 
-	minDuration := time.Duration(1<<63 - 1)
-	var maxDuration time.Duration
+	minDuration := b.buildHistory[0].Duration
+	maxDuration := b.buildHistory[0].Duration
 
 	for _, record := range b.buildHistory {
 		// Duration stats

--- a/internal/building/building_test.go
+++ b/internal/building/building_test.go
@@ -177,6 +177,32 @@ func TestBuildingRecordBuild_NilResult(t *testing.T) {
 	}
 }
 
+func TestMetrics_ZeroValues(t *testing.T) {
+	metrics := Metrics{}
+
+	if metrics.TotalBuilds != 0 {
+		t.Errorf("TotalBuilds zero value = %d, want 0", metrics.TotalBuilds)
+	}
+	if metrics.SuccessRate != 0.0 {
+		t.Errorf("SuccessRate zero value = %v, want 0.0", metrics.SuccessRate)
+	}
+	if metrics.AvgCacheHitRate != 0.0 {
+		t.Errorf("AvgCacheHitRate zero value = %v, want 0.0", metrics.AvgCacheHitRate)
+	}
+	if metrics.MinDuration != 0 {
+		t.Errorf("MinDuration zero value = %v, want 0", metrics.MinDuration)
+	}
+	if metrics.MaxDuration != 0 {
+		t.Errorf("MaxDuration zero value = %v, want 0", metrics.MaxDuration)
+	}
+	if metrics.AvgDuration != 0 {
+		t.Errorf("AvgDuration zero value = %v, want 0", metrics.AvgDuration)
+	}
+	if metrics.LastDuration != 0 {
+		t.Errorf("LastDuration zero value = %v, want 0", metrics.LastDuration)
+	}
+}
+
 func TestBuildingMetrics_MultipleBuilds(t *testing.T) {
 	target := build.Target{ID: "test", Name: "test"}
 	b := New(target, "bazel", 0, 0)

--- a/internal/unit/unit.go
+++ b/internal/unit/unit.go
@@ -72,7 +72,7 @@ type TestMetrics struct {
 	PassCount int
 	FailCount int
 
-	// Timing statistics
+	// Timing statistics (zero when TotalRuns == 0)
 	AvgDuration  time.Duration
 	MinDuration  time.Duration
 	MaxDuration  time.Duration
@@ -110,9 +110,6 @@ func New(id, name string, x, y float64) *Unit {
 		y:          y,
 		state:      UnitStateIdle,
 		runHistory: make([]TestRun, 0),
-		metrics: TestMetrics{
-			MinDuration: time.Duration(1<<63 - 1), // Max int64
-		},
 	}
 }
 
@@ -231,8 +228,8 @@ func (u *Unit) updateMetrics() {
 	var totalDuration time.Duration
 	var passCount int
 
-	minDuration := time.Duration(1<<63 - 1)
-	var maxDuration time.Duration
+	minDuration := u.runHistory[0].Duration
+	maxDuration := u.runHistory[0].Duration
 
 	for _, run := range u.runHistory {
 		// Duration stats

--- a/internal/unit/unit_test.go
+++ b/internal/unit/unit_test.go
@@ -425,6 +425,18 @@ func TestTestMetrics_ZeroValues(t *testing.T) {
 	if metrics.CoveragePercent != 0.0 {
 		t.Errorf("CoveragePercent zero value = %v, want 0.0", metrics.CoveragePercent)
 	}
+	if metrics.MinDuration != 0 {
+		t.Errorf("MinDuration zero value = %v, want 0", metrics.MinDuration)
+	}
+	if metrics.MaxDuration != 0 {
+		t.Errorf("MaxDuration zero value = %v, want 0", metrics.MaxDuration)
+	}
+	if metrics.AvgDuration != 0 {
+		t.Errorf("AvgDuration zero value = %v, want 0", metrics.AvgDuration)
+	}
+	if metrics.LastDuration != 0 {
+		t.Errorf("LastDuration zero value = %v, want 0", metrics.LastDuration)
+	}
 }
 
 func TestTestResult_Fields(t *testing.T) {


### PR DESCRIPTION
## Summary
- drop MaxInt64 sentinels for MinDuration and initialize on first data point
- compute min/max durations without sentinel values in building/unit/advisor metrics
- add zero-value metrics coverage tests

## Testing
- nix develop --command bazel build //...
- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...
- nix develop --command go fmt ./...