### PR TITLE
P4.2: Clamp percentages and ratios

### DIFF
--- a/internal/multiagent/renderer.go
+++ b/internal/multiagent/renderer.go
@@ -169,7 +169,7 @@ func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
 	usageY := y + 68
 	usageWidth := agentCardWidth - 16
 	usageHeight := 12
-	usage := agent.ContextUsage()
+	usage := clampUnitInterval(agent.ContextUsage())
 
 	// Background
 	vector.DrawFilledRect(screen, float32(x+8), float32(usageY), float32(usageWidth), float32(usageHeight),
@@ -202,6 +202,16 @@ func getUsageColor(usage float64) color.RGBA {
 		return color.RGBA{R: 0xF5, G: 0x7F, B: 0x17, A: 0xFF} // Orange
 	}
 	return color.RGBA{R: 0xC6, G: 0x28, B: 0x28, A: 0xFF} // Red
+}
+
+func clampUnitInterval(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
 }
 
 // GetStatusColor returns the color associated with a status.

--- a/internal/multiagent/renderer_test.go
+++ b/internal/multiagent/renderer_test.go
@@ -87,6 +87,25 @@ func TestGetUsageColor(t *testing.T) {
 	}
 }
 
+func TestClampUnitInterval(t *testing.T) {
+	tests := []struct {
+		value    float64
+		expected float64
+	}{
+		{-0.5, 0},
+		{0, 0},
+		{0.35, 0.35},
+		{1, 1},
+		{1.25, 1},
+	}
+
+	for _, tc := range tests {
+		if got := clampUnitInterval(tc.value); got != tc.expected {
+			t.Errorf("clampUnitInterval(%v) = %v, want %v", tc.value, got, tc.expected)
+		}
+	}
+}
+
 func TestTokenSummaryXGuard(t *testing.T) {
 	x := 5
 

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -111,10 +111,7 @@ func (t *Tracker) drawResource(screen *ebiten.Image, r *Resource, x, y, width, h
 	// Calculate fill percentage
 	fillPct := float32(0)
 	if r.Max > 0 {
-		fillPct = float32(r.Current) / float32(r.Max)
-		if fillPct > 1.0 {
-			fillPct = 1.0
-		}
+		fillPct = clampRatio(float32(r.Current) / float32(r.Max))
 	}
 
 	// Draw resource bar background
@@ -148,6 +145,16 @@ func (t *Tracker) drawResource(screen *ebiten.Image, r *Resource, x, y, width, h
 	// Draw resource text
 	text := t.formatResourceText(r)
 	ebitenutil.DebugPrintAt(screen, text, x+padding, y+5)
+}
+
+func clampRatio(value float32) float32 {
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
 }
 
 // formatResourceText formats the resource display text

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -121,6 +121,25 @@ func TestFormatResourceText(t *testing.T) {
 	}
 }
 
+func TestClampRatio(t *testing.T) {
+	tests := []struct {
+		value    float32
+		expected float32
+	}{
+		{-0.25, 0},
+		{0, 0},
+		{0.4, 0.4},
+		{1, 1},
+		{1.1, 1},
+	}
+
+	for _, tc := range tests {
+		if got := clampRatio(tc.value); got != tc.expected {
+			t.Errorf("clampRatio(%v) = %v, want %v", tc.value, got, tc.expected)
+		}
+	}
+}
+
 func TestGetResourceNotFound(t *testing.T) {
 	tracker := New()
 

--- a/internal/unit/unit.go
+++ b/internal/unit/unit.go
@@ -218,7 +218,17 @@ func (u *Unit) SetPosition(x, y float64) {
 func (u *Unit) SetCoverage(percent float64) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	u.metrics.CoveragePercent = percent
+	u.metrics.CoveragePercent = clampPercent(percent)
+}
+
+func clampPercent(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
 }
 
 // updateMetrics recalculates aggregated metrics from run history

--- a/internal/unit/unit_test.go
+++ b/internal/unit/unit_test.go
@@ -254,6 +254,20 @@ func TestUnitSetCoverage(t *testing.T) {
 	}
 }
 
+func TestUnitSetCoverageClamps(t *testing.T) {
+	u := New("test", "test", 0, 0)
+
+	u.SetCoverage(-12.5)
+	if got := u.Metrics().CoveragePercent; got != 0 {
+		t.Errorf("CoveragePercent = %v, want 0", got)
+	}
+
+	u.SetCoverage(250.0)
+	if got := u.Metrics().CoveragePercent; got != 100 {
+		t.Errorf("CoveragePercent = %v, want 100", got)
+	}
+}
+
 func TestUnitRunHistory(t *testing.T) {
 	u := New("test", "test", 0, 0)
 


### PR DESCRIPTION
## Summary
- clamp unit coverage percentage to [0,100]
- clamp multiagent context usage and resource bar fill ratios before rendering
- add boundary tests for clamp helpers

## Testing
- nix develop --command go fmt ./...
- nix develop --command bazel build //...
- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...