### PR TITLE
P4.3: Return copies instead of internal references

### DIFF
--- a/internal/capability/registry.go
+++ b/internal/capability/registry.go
@@ -95,15 +95,16 @@ func (r *Registry) Refresh() int {
 	// Notify listeners (with panic recovery to prevent listener crashes from taking down the registry)
 	all := r.GetAll()
 	for _, l := range listeners {
-		go func(listener RegistryListener) {
+		caps := cloneCapabilities(all)
+		go func(listener RegistryListener, caps []*Capability) {
 			defer func() {
 				if rec := recover(); rec != nil {
 					// Silently ignore panics from listeners
 					// In production, this could be logged
 				}
 			}()
-			listener.OnCapabilitiesChanged(all)
-		}(l)
+			listener.OnCapabilitiesChanged(caps)
+		}(l, caps)
 	}
 
 	return len(newCaps)
@@ -141,7 +142,7 @@ func (r *Registry) GetAll() []*Capability {
 
 	caps := make([]*Capability, 0, len(r.capabilities))
 	for _, cap := range r.capabilities {
-		caps = append(caps, cap)
+		caps = append(caps, cloneCapability(cap))
 	}
 
 	// Sort by domain first, then by name within domain
@@ -163,7 +164,7 @@ func (r *Registry) GetByDomain(domain Domain) []*Capability {
 	var caps []*Capability
 	for _, cap := range r.capabilities {
 		if cap.Domain == domain {
-			caps = append(caps, cap)
+			caps = append(caps, cloneCapability(cap))
 		}
 	}
 
@@ -182,7 +183,7 @@ func (r *Registry) GetByType(capType CapabilityType) []*Capability {
 	var caps []*Capability
 	for _, cap := range r.capabilities {
 		if cap.Type == capType {
-			caps = append(caps, cap)
+			caps = append(caps, cloneCapability(cap))
 		}
 	}
 
@@ -197,7 +198,7 @@ func (r *Registry) GetByType(capType CapabilityType) []*Capability {
 func (r *Registry) Get(id string) *Capability {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.capabilities[id]
+	return cloneCapability(r.capabilities[id])
 }
 
 // Count returns the total number of capabilities.
@@ -229,6 +230,25 @@ func (r *Registry) WatchPaths() []string {
 		paths = append(paths, d.WatchPaths()...)
 	}
 	return paths
+}
+
+func cloneCapabilities(caps []*Capability) []*Capability {
+	if caps == nil {
+		return nil
+	}
+	cloned := make([]*Capability, len(caps))
+	for i, cap := range caps {
+		cloned[i] = cloneCapability(cap)
+	}
+	return cloned
+}
+
+func cloneCapability(capability *Capability) *Capability {
+	if capability == nil {
+		return nil
+	}
+	cloned := *capability
+	return &cloned
 }
 
 // domainOrder returns the sort order for a domain.

--- a/internal/capability/registry_test.go
+++ b/internal/capability/registry_test.go
@@ -220,6 +220,60 @@ func TestRegistryListener(t *testing.T) {
 	}
 }
 
+func TestRegistryListenerReceivesCopy(t *testing.T) {
+	r := NewRegistry()
+
+	ready := make(chan struct{})
+	firstCalled := make(chan struct{}, 1)
+	secondCalled := make(chan []*Capability, 1)
+
+	first := &testListener{
+		onChanged: func(caps []*Capability) {
+			if len(caps) > 0 {
+				caps[0].Name = "mutated"
+			}
+			close(ready)
+			firstCalled <- struct{}{}
+		},
+	}
+	second := &testListener{
+		onChanged: func(caps []*Capability) {
+			<-ready
+			secondCalled <- caps
+		},
+	}
+
+	r.AddListener(first)
+	r.AddListener(second)
+
+	mock := &mockDiscoverer{
+		name: "test",
+		capabilities: []*Capability{
+			NewCapability("cap1", "Cap 1", TypeTool, DomainCore),
+		},
+	}
+	r.RegisterDiscoverer(mock)
+	r.Refresh()
+
+	select {
+	case <-firstCalled:
+	case <-time.After(1 * time.Second):
+		t.Fatal("first listener was not called within timeout")
+	}
+
+	select {
+	case caps := <-secondCalled:
+		if len(caps) != 1 {
+			t.Fatalf("expected 1 capability, got %d", len(caps))
+		}
+		if caps[0].Name != "Cap 1" {
+			t.Errorf("expected capability name 'Cap 1', got %q", caps[0].Name)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("second listener was not called within timeout")
+	}
+}
+
 func TestRegistryRemoveListener(t *testing.T) {
 	r := NewRegistry()
 

--- a/internal/debug/BUILD.bazel
+++ b/internal/debug/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "adapter.go",
         "breakpoint.go",
+        "clone.go",
         "dataflow.go",
         "debug.go",
         "event.go",

--- a/internal/debug/clone.go
+++ b/internal/debug/clone.go
@@ -1,0 +1,43 @@
+package debug
+
+func cloneFrames(frames []*Frame) []*Frame {
+	if frames == nil {
+		return nil
+	}
+	cloned := make([]*Frame, len(frames))
+	for i, frame := range frames {
+		cloned[i] = cloneFrame(frame)
+	}
+	return cloned
+}
+
+func cloneFrame(frame *Frame) *Frame {
+	if frame == nil {
+		return nil
+	}
+	cloned := *frame
+	cloned.Arguments = cloneVariables(frame.Arguments)
+	cloned.Locals = cloneVariables(frame.Locals)
+	cloned.Returns = cloneVariables(frame.Returns)
+	return &cloned
+}
+
+func cloneVariables(vars []*Variable) []*Variable {
+	if vars == nil {
+		return nil
+	}
+	cloned := make([]*Variable, len(vars))
+	for i, v := range vars {
+		cloned[i] = cloneVariable(v)
+	}
+	return cloned
+}
+
+func cloneVariable(v *Variable) *Variable {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	cloned.Children = cloneVariables(v.Children)
+	return &cloned
+}

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -148,9 +148,7 @@ func (s *Session) SetState(state State) {
 func (s *Session) Frames() []*Frame {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	result := make([]*Frame, len(s.frames))
-	copy(result, s.frames)
-	return result
+	return cloneFrames(s.frames)
 }
 
 // CurrentFrame returns the topmost stack frame, or nil if none.
@@ -160,15 +158,16 @@ func (s *Session) CurrentFrame() *Frame {
 	if len(s.frames) == 0 {
 		return nil
 	}
-	return s.frames[0]
+	return cloneFrame(s.frames[0])
 }
 
 // SetFrames updates the call stack.
 func (s *Session) SetFrames(frames []*Frame) {
 	s.mu.Lock()
-	s.frames = frames
+	s.frames = cloneFrames(frames)
 	handlers := make([]EventHandler, len(s.handlers))
 	copy(handlers, s.handlers)
+	frameCount := len(s.frames)
 	s.mu.Unlock()
 
 	event := &Event{
@@ -176,7 +175,7 @@ func (s *Session) SetFrames(frames []*Frame) {
 		SessionID: s.id,
 		Timestamp: time.Now(),
 		Data: map[string]interface{}{
-			"frame_count": len(frames),
+			"frame_count": frameCount,
 		},
 	}
 	for _, h := range handlers {

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -51,6 +51,7 @@ func TestSessionFrames(t *testing.T) {
 	s := NewSession("test-1", "go", "/project")
 
 	frame1 := NewFrame(0, "main.doWork", "main.go", 42)
+	frame1.AddArgument(NewVariable("x", "int", "1"))
 	frame2 := NewFrame(1, "main.main", "main.go", 10)
 
 	s.SetFrames([]*Frame{frame1, frame2})
@@ -59,13 +60,44 @@ func TestSessionFrames(t *testing.T) {
 	if len(frames) != 2 {
 		t.Fatalf("expected 2 frames, got %d", len(frames))
 	}
+	if frames[0].Function != "main.doWork" {
+		t.Errorf("expected function 'main.doWork', got '%s'", frames[0].Function)
+	}
+
+	// Mutate returned frames to ensure they are copies.
+	frames[0].Function = "mutated"
+	if len(frames[0].Arguments) != 1 {
+		t.Fatalf("expected 1 argument, got %d", len(frames[0].Arguments))
+	}
+	frames[0].Arguments[0].Name = "mutated"
 
 	current := s.CurrentFrame()
-	if current != frame1 {
-		t.Error("expected current frame to be frame1")
+	if current == nil {
+		t.Fatal("expected current frame, got nil")
 	}
 	if current.Function != "main.doWork" {
 		t.Errorf("expected function 'main.doWork', got '%s'", current.Function)
+	}
+	if len(current.Arguments) != 1 {
+		t.Errorf("expected 1 argument, got %d", len(current.Arguments))
+	} else if current.Arguments[0].Name != "x" {
+		t.Errorf("expected argument name 'x', got '%s'", current.Arguments[0].Name)
+	}
+
+	// Mutate original frame after SetFrames to ensure session cloned inputs.
+	frame1.Function = "changed"
+	frame1.Arguments[0].Name = "changed"
+	currentAgain := s.CurrentFrame()
+	if currentAgain == nil {
+		t.Fatal("expected current frame, got nil")
+	}
+	if currentAgain.Function != "main.doWork" {
+		t.Errorf("expected function 'main.doWork', got '%s'", currentAgain.Function)
+	}
+	if len(currentAgain.Arguments) != 1 {
+		t.Errorf("expected 1 argument, got %d", len(currentAgain.Arguments))
+	} else if currentAgain.Arguments[0].Name != "x" {
+		t.Errorf("expected argument name 'x', got '%s'", currentAgain.Arguments[0].Name)
 	}
 }
 

--- a/internal/production/registry.go
+++ b/internal/production/registry.go
@@ -95,15 +95,16 @@ func (r *Registry) Refresh() int {
 	// Notify listeners (with panic recovery to prevent listener crashes from taking down the registry)
 	all := r.GetAll()
 	for _, l := range listeners {
-		go func(listener RegistryListener) {
+		services := cloneServices(all)
+		go func(listener RegistryListener, services []*Service) {
 			defer func() {
 				if rec := recover(); rec != nil {
 					// Silently ignore panics from listeners
 					// In production, this could be logged
 				}
 			}()
-			listener.OnServicesChanged(all)
-		}(l)
+			listener.OnServicesChanged(services)
+		}(l, services)
 	}
 
 	return len(newServices)
@@ -141,7 +142,7 @@ func (r *Registry) GetAll() []*Service {
 
 	services := make([]*Service, 0, len(r.services))
 	for _, svc := range r.services {
-		services = append(services, svc)
+		services = append(services, cloneService(svc))
 	}
 
 	sort.Slice(services, func(i, j int) bool {
@@ -159,7 +160,7 @@ func (r *Registry) GetByType(serviceType ServiceType) []*Service {
 	var services []*Service
 	for _, svc := range r.services {
 		if svc.Type == serviceType {
-			services = append(services, svc)
+			services = append(services, cloneService(svc))
 		}
 	}
 
@@ -178,7 +179,7 @@ func (r *Registry) GetByHealth(health HealthStatus) []*Service {
 	var services []*Service
 	for _, svc := range r.services {
 		if svc.Health == health {
-			services = append(services, svc)
+			services = append(services, cloneService(svc))
 		}
 	}
 
@@ -193,7 +194,7 @@ func (r *Registry) GetByHealth(health HealthStatus) []*Service {
 func (r *Registry) Get(id string) *Service {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.services[id]
+	return cloneService(r.services[id])
 }
 
 // Count returns the total number of services.
@@ -225,6 +226,31 @@ func (r *Registry) WatchPaths() []string {
 		paths = append(paths, d.WatchPaths()...)
 	}
 	return paths
+}
+
+func cloneServices(services []*Service) []*Service {
+	if services == nil {
+		return nil
+	}
+	cloned := make([]*Service, len(services))
+	for i, svc := range services {
+		cloned[i] = cloneService(svc)
+	}
+	return cloned
+}
+
+func cloneService(service *Service) *Service {
+	if service == nil {
+		return nil
+	}
+	cloned := *service
+	if service.Dependencies != nil {
+		cloned.Dependencies = append([]string(nil), service.Dependencies...)
+	}
+	if service.Dependents != nil {
+		cloned.Dependents = append([]string(nil), service.Dependents...)
+	}
+	return &cloned
 }
 
 // GetWeatherSummary returns a summary of weather conditions across all services.

--- a/internal/production/registry_test.go
+++ b/internal/production/registry_test.go
@@ -227,6 +227,60 @@ func TestRegistryListener(t *testing.T) {
 	}
 }
 
+func TestRegistryListenerReceivesCopy(t *testing.T) {
+	r := NewRegistry()
+
+	ready := make(chan struct{})
+	firstCalled := make(chan struct{}, 1)
+	secondCalled := make(chan []*Service, 1)
+
+	first := &testListener{
+		onChanged: func(services []*Service) {
+			if len(services) > 0 {
+				services[0].Name = "mutated"
+			}
+			close(ready)
+			firstCalled <- struct{}{}
+		},
+	}
+	second := &testListener{
+		onChanged: func(services []*Service) {
+			<-ready
+			secondCalled <- services
+		},
+	}
+
+	r.AddListener(first)
+	r.AddListener(second)
+
+	mock := &mockDiscoverer{
+		name: "test",
+		services: []*Service{
+			NewService("api", "API", ServiceTypeHTTP, "http://localhost"),
+		},
+	}
+	r.RegisterDiscoverer(mock)
+	r.Refresh()
+
+	select {
+	case <-firstCalled:
+	case <-time.After(1 * time.Second):
+		t.Fatal("first listener was not called within timeout")
+	}
+
+	select {
+	case services := <-secondCalled:
+		if len(services) != 1 {
+			t.Fatalf("expected 1 service, got %d", len(services))
+		}
+		if services[0].Name != "API" {
+			t.Errorf("expected service name 'API', got %q", services[0].Name)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("second listener was not called within timeout")
+	}
+}
+
 func TestRegistryRemoveListener(t *testing.T) {
 	r := NewRegistry()
 

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -187,14 +187,16 @@ func (t *Tracker) AddResource(r *Resource) {
 	t.resources = append(t.resources, r)
 }
 
-// GetResource retrieves a resource by name
+// GetResource retrieves a resource by name.
+// Returns a copy so callers cannot mutate internal state.
 func (t *Tracker) GetResource(name string) *Resource {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
 	for _, r := range t.resources {
 		if r.Name == name {
-			return r
+			resourceCopy := *r
+			return &resourceCopy
 		}
 	}
 	return nil

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -130,6 +130,24 @@ func TestGetResourceNotFound(t *testing.T) {
 	}
 }
 
+func TestGetResourceReturnsCopy(t *testing.T) {
+	tracker := New()
+
+	res := tracker.GetResource("Context")
+	if res == nil {
+		t.Fatal("expected Context resource to exist")
+	}
+
+	res.Current = 999
+	resAgain := tracker.GetResource("Context")
+	if resAgain == nil {
+		t.Fatal("expected Context resource to exist")
+	}
+	if resAgain.Current == 999 {
+		t.Error("GetResource returned a reference instead of a copy")
+	}
+}
+
 func TestConcurrentAccess(t *testing.T) {
 	tracker := New()
 

--- a/internal/unit/unit.go
+++ b/internal/unit/unit.go
@@ -151,11 +151,16 @@ func (u *Unit) Metrics() TestMetrics {
 	return u.metrics
 }
 
-// LastTestResult returns the most recent test result, or nil if never run
+// LastTestResult returns the most recent test result, or nil if never run.
+// Returns a copy so callers cannot mutate internal state.
 func (u *Unit) LastTestResult() *TestResult {
 	u.mu.RLock()
 	defer u.mu.RUnlock()
-	return u.lastRun
+	if u.lastRun == nil {
+		return nil
+	}
+	resultCopy := *u.lastRun
+	return &resultCopy
 }
 
 // StartTest marks the unit as currently running
@@ -183,22 +188,24 @@ func (u *Unit) RecordTest(result *TestResult) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
+	resultCopy := *result
+
 	// Update state based on result
-	if result.Passed {
+	if resultCopy.Passed {
 		u.state = UnitStatePassed
 	} else {
 		u.state = UnitStateFailed
 	}
 
 	// Store last result
-	u.lastRun = result
+	u.lastRun = &resultCopy
 
 	// Add to history
 	run := TestRun{
-		Timestamp: result.Timestamp,
-		Duration:  result.Duration,
-		Passed:    result.Passed,
-		Output:    result.Output,
+		Timestamp: resultCopy.Timestamp,
+		Duration:  resultCopy.Duration,
+		Passed:    resultCopy.Passed,
+		Output:    resultCopy.Output,
 	}
 	u.runHistory = append(u.runHistory, run)
 

--- a/internal/unit/unit_test.go
+++ b/internal/unit/unit_test.go
@@ -101,6 +101,39 @@ func TestUnitRecordTest_Passed(t *testing.T) {
 	}
 }
 
+func TestUnitLastTestResultReturnsCopy(t *testing.T) {
+	u := New("test", "test", 0, 0)
+	now := time.Now()
+	result := &TestResult{
+		Passed:    true,
+		Duration:  100 * time.Millisecond,
+		Timestamp: now,
+	}
+
+	u.RecordTest(result)
+
+	// Mutate original result after recording.
+	result.Passed = false
+
+	last := u.LastTestResult()
+	if last == nil {
+		t.Fatal("LastTestResult() returned nil")
+	}
+	if !last.Passed {
+		t.Error("LastTestResult() reflected external mutation")
+	}
+
+	// Mutate returned result and ensure internal state is unchanged.
+	last.Passed = false
+	lastAgain := u.LastTestResult()
+	if lastAgain == nil {
+		t.Fatal("LastTestResult() returned nil")
+	}
+	if !lastAgain.Passed {
+		t.Error("LastTestResult() returned a reference instead of a copy")
+	}
+}
+
 func TestUnitRecordTest_Failed(t *testing.T) {
 	u := New("test", "test", 0, 0)
 


### PR DESCRIPTION
## Summary
- return copies for resource/unit/debug data to prevent external mutation
- clone debug frames and registry payloads for listener isolation
- add mutation-isolation tests for resources, units, debug frames, and registries

## Testing
- nix develop --command bazel build //...
- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...