### PR TITLE
P5.4: Improve struct+mutex+getters pattern

### DIFF
--- a/internal/capability/watcher.go
+++ b/internal/capability/watcher.go
@@ -12,6 +12,25 @@ import (
 // Config files change infrequently, so the 5-second default interval is appropriate.
 // Benefits: No file handle exhaustion, works on all platforms, simple implementation.
 // Trade-off: Small delay (configurable) between file change and detection.
+//
+// # Concurrency
+//
+// mu protects: registry, pollInterval, running, stopCh, newTicker.
+// fileTimesMu protects: fileTimes.
+//
+// Goroutines:
+// - poll: started by Start, exits when stopCh is closed.
+//
+// Channel: stopCh (chan struct{})
+// - Created by: Start
+// - Closed by: Stop
+// - Read by: poll
+//
+// # State machine
+//
+// Idle -> Running -> Stopped
+// Start is idempotent; Stop is idempotent. A watcher may be restarted after Stop,
+// which creates a new stopCh and poll goroutine.
 type Watcher struct {
 	mu sync.Mutex
 
@@ -25,6 +44,14 @@ type Watcher struct {
 	// File modification times for change detection
 	fileTimesMu sync.Mutex
 	fileTimes   map[string]time.Time
+}
+
+// WatcherSnapshot is an immutable, point-in-time view of watcher state.
+// Modifying the snapshot does not affect the underlying watcher.
+type WatcherSnapshot struct {
+	Running      bool
+	PollInterval time.Duration
+	TrackedPaths int
 }
 
 type ticker interface {
@@ -121,6 +148,24 @@ func (w *Watcher) IsRunning() bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.running
+}
+
+// Snapshot returns an immutable, point-in-time view of watcher state.
+func (w *Watcher) Snapshot() WatcherSnapshot {
+	w.mu.Lock()
+	running := w.running
+	pollInterval := w.pollInterval
+	w.mu.Unlock()
+
+	w.fileTimesMu.Lock()
+	tracked := len(w.fileTimes)
+	w.fileTimesMu.Unlock()
+
+	return WatcherSnapshot{
+		Running:      running,
+		PollInterval: pollInterval,
+		TrackedPaths: tracked,
+	}
 }
 
 // poll is the main polling loop.

--- a/internal/debug/clone.go
+++ b/internal/debug/clone.go
@@ -41,3 +41,42 @@ func cloneVariable(v *Variable) *Variable {
 	cloned.Children = cloneVariables(v.Children)
 	return &cloned
 }
+
+func cloneDataFlows(flows []*DataFlow) []*DataFlow {
+	if flows == nil {
+		return nil
+	}
+	cloned := make([]*DataFlow, len(flows))
+	for i, flow := range flows {
+		cloned[i] = cloneDataFlow(flow)
+	}
+	return cloned
+}
+
+func cloneDataFlow(flow *DataFlow) *DataFlow {
+	if flow == nil {
+		return nil
+	}
+	cloned := *flow
+	cloned.Variables = cloneVariables(flow.Variables)
+	return &cloned
+}
+
+func cloneBreakpoints(bps map[string]*Breakpoint) []*Breakpoint {
+	if bps == nil {
+		return nil
+	}
+	cloned := make([]*Breakpoint, 0, len(bps))
+	for _, bp := range bps {
+		cloned = append(cloned, cloneBreakpoint(bp))
+	}
+	return cloned
+}
+
+func cloneBreakpoint(bp *Breakpoint) *Breakpoint {
+	if bp == nil {
+		return nil
+	}
+	cloned := *bp
+	return &cloned
+}

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -53,6 +53,18 @@ func (s State) String() string {
 
 // Session represents an active debugging session.
 //
+// # Concurrency
+//
+// mu protects all fields on Session. Event handlers are invoked without holding mu;
+// handlers must be thread-safe and should avoid long-running work.
+//
+// # State machine
+//
+// Idle -> Running -> Paused -> Running
+// Running/Paused -> Stopped
+// Stopped is terminal. SetState does not enforce transitions; callers must
+// follow the expected sequence.
+//
 // Thread-safe: All methods are safe for concurrent access.
 type Session struct {
 	mu sync.RWMutex
@@ -74,6 +86,19 @@ type Session struct {
 
 	// Event handlers
 	handlers []EventHandler
+}
+
+// SessionSnapshot is an immutable, point-in-time view of session state.
+// Modifying the snapshot does not affect the underlying session.
+type SessionSnapshot struct {
+	ID          string
+	Language    string
+	TargetDir   string
+	StartTime   time.Time
+	State       State
+	Frames      []*Frame
+	DataFlows   []*DataFlow
+	Breakpoints []*Breakpoint
 }
 
 // NewSession creates a new debug session.
@@ -116,6 +141,22 @@ func (s *Session) State() State {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.state
+}
+
+// Snapshot returns an immutable, point-in-time view of session state.
+func (s *Session) Snapshot() SessionSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return SessionSnapshot{
+		ID:          s.id,
+		Language:    s.language,
+		TargetDir:   s.targetDir,
+		StartTime:   s.startTime,
+		State:       s.state,
+		Frames:      cloneFrames(s.frames),
+		DataFlows:   cloneDataFlows(s.dataFlows),
+		Breakpoints: cloneBreakpoints(s.breakpoints),
+	}
 }
 
 // SetState updates the session state and notifies handlers.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -72,10 +72,14 @@ type HarnessFactory func() Harness
 
 // BaseHarness provides common functionality for harness implementations.
 //
-// # Thread Safety
+// # Concurrency
 //
 // BaseHarness is designed for concurrent use with the following guarantees:
 //
+//   - mu protects: version, running, stopped, closed.
+//   - name is immutable after construction (NewBaseHarness).
+//   - events is created by NewBaseHarness and closed by CloseEvents.
+//   - closeOnce enforces a single close of events.
 //   - IsRunning() and SetRunning() are protected by a mutex and safe to call
 //     from multiple goroutines.
 //   - Events() returns a receive-only channel that can be read by one consumer.
@@ -113,6 +117,16 @@ type BaseHarness struct {
 	closed    bool
 }
 
+// BaseHarnessSnapshot is an immutable, point-in-time view of BaseHarness state.
+// Modifying the snapshot does not affect the underlying harness.
+type BaseHarnessSnapshot struct {
+	Name         string
+	Version      string
+	Running      bool
+	Stopped      bool
+	EventsClosed bool
+}
+
 // NewBaseHarness creates a new base harness with the given name
 func NewBaseHarness(name string) *BaseHarness {
 	return &BaseHarness{
@@ -131,6 +145,19 @@ func (b *BaseHarness) Version() string {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return b.version
+}
+
+// Snapshot returns an immutable, point-in-time view of the harness state.
+func (b *BaseHarness) Snapshot() BaseHarnessSnapshot {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return BaseHarnessSnapshot{
+		Name:         b.name,
+		Version:      b.version,
+		Running:      b.running,
+		Stopped:      b.stopped,
+		EventsClosed: b.closed,
+	}
 }
 
 // SetVersion sets the harness version

--- a/internal/multiagent/agent.go
+++ b/internal/multiagent/agent.go
@@ -35,6 +35,21 @@ const (
 
 // Agent represents an active Claude agent with its own context boundary.
 // Each agent maintains its own "fog of war" - the set of files it has read.
+//
+// # Concurrency
+//
+// mu protects all fields on Agent. The id, name, and icon are immutable after
+// construction; all other fields are mutable and guarded by mu.
+//
+// # State machine
+//
+// Idle -> Working -> Paused -> Working
+// Working/Paused -> Completed
+// Any state -> Error (SetError)
+// Reset returns the agent to Idle and clears context.
+//
+// StartTask only transitions to Working from non-Working states, PauseTask only
+// transitions from Working, and ResumeTask only transitions from Paused.
 type Agent struct {
 	mu sync.RWMutex
 
@@ -63,6 +78,23 @@ type Agent struct {
 
 	// Error tracking
 	lastError error
+}
+
+// AgentSnapshot is an immutable, point-in-time view of agent state.
+// Modifying the snapshot does not affect the underlying agent.
+type AgentSnapshot struct {
+	ID           string
+	Name         string
+	Icon         string
+	Status       AgentStatus
+	CurrentTask  string
+	LastActivity time.Time
+	TokensUsed   int64
+	TokenLimit   int64
+	ContextUsage float64
+	FileCount    int
+	PositionX    float64
+	PositionY    float64
 }
 
 // NewAgent creates a new agent with the given parameters.
@@ -97,6 +129,26 @@ func (a *Agent) Icon() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.icon
+}
+
+// Snapshot returns an immutable, point-in-time view of agent state.
+func (a *Agent) Snapshot() AgentSnapshot {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return AgentSnapshot{
+		ID:           a.id,
+		Name:         a.name,
+		Icon:         a.icon,
+		Status:       a.status,
+		CurrentTask:  a.currentTask,
+		LastActivity: a.lastActivity,
+		TokensUsed:   a.tokensUsed,
+		TokenLimit:   a.tokenLimit,
+		ContextUsage: a.contextUsage,
+		FileCount:    len(a.filesRead),
+		PositionX:    a.x,
+		PositionY:    a.y,
+	}
 }
 
 // Status returns the agent's current status.

--- a/internal/multiagent/orchestrator.go
+++ b/internal/multiagent/orchestrator.go
@@ -32,6 +32,7 @@ func AbandonedListenerCount() int64 {
 type OrchestratorListener interface {
 	// OnAgentsChanged is called when agents are added, removed, or updated.
 	// The provided slice is read-only and must not be modified.
+	// For an immutable, point-in-time view, call Agent.Snapshot on each entry.
 	// Listeners are called asynchronously in goroutines.
 	// The context is canceled when the listener times out.
 	// Implementations should return promptly when ctx.Done() is closed.
@@ -44,6 +45,13 @@ type OrchestratorListener interface {
 // - Assigning tasks to agents
 // - Monitoring agent status
 // - Coordinating agent handoffs
+//
+// # Concurrency
+//
+// mu protects: agents, listeners, nextID.
+// The agents map is keyed by agent.ID and IDs are immutable after creation.
+// Listener callbacks are invoked without holding mu; a snapshot of listeners is
+// taken to avoid holding the lock across user code.
 type Orchestrator struct {
 	mu sync.RWMutex
 
@@ -109,6 +117,8 @@ func (o *Orchestrator) Get(id string) *Agent {
 }
 
 // GetAll returns all agents sorted by name.
+// The returned slice contains live agent pointers; use Agent.Snapshot for a
+// read-only copy of agent state.
 func (o *Orchestrator) GetAll() []*Agent {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
@@ -123,6 +133,26 @@ func (o *Orchestrator) GetAll() []*Agent {
 	})
 
 	return agents
+}
+
+// Snapshots returns immutable snapshots of all agents sorted by name.
+func (o *Orchestrator) Snapshots() []AgentSnapshot {
+	o.mu.RLock()
+	agents := make([]*Agent, 0, len(o.agents))
+	for _, agent := range o.agents {
+		agents = append(agents, agent)
+	}
+	o.mu.RUnlock()
+
+	snapshots := make([]AgentSnapshot, len(agents))
+	for i, agent := range agents {
+		snapshots[i] = agent.Snapshot()
+	}
+
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].Name < snapshots[j].Name
+	})
+	return snapshots
 }
 
 // Count returns the total number of agents.

--- a/internal/multiagent/renderer.go
+++ b/internal/multiagent/renderer.go
@@ -44,18 +44,23 @@ var statusColors = map[AgentStatus]color.RGBA{
 //   - x, y: the top-left position to start drawing
 //   - width, height: the available drawing area
 func (r *Renderer) Draw(screen *ebiten.Image, agents []*Agent, x, y, width, height int) {
+	snapshots := make([]AgentSnapshot, len(agents))
+	for i, agent := range agents {
+		snapshots[i] = agent.Snapshot()
+	}
+
 	// Draw header with summary
-	r.drawHeader(screen, agents, x, y, width)
+	r.drawHeader(screen, snapshots, x, y, width)
 
 	// If no agents, show empty state
-	if len(agents) == 0 {
+	if len(snapshots) == 0 {
 		r.drawEmptyState(screen, x, y+agentHeaderHeight, width, height-agentHeaderHeight)
 		return
 	}
 
 	// Draw agents as cards
 	startY := y + agentHeaderHeight + agentPadding
-	for i, agent := range agents {
+	for i, agent := range snapshots {
 		row := i / agentCardsPerRow
 		col := i % agentCardsPerRow
 
@@ -81,7 +86,7 @@ func tokenSummaryX(x, width int) (int, bool) {
 }
 
 // drawHeader renders the summary header.
-func (r *Renderer) drawHeader(screen *ebiten.Image, agents []*Agent, x, y, width int) {
+func (r *Renderer) drawHeader(screen *ebiten.Image, agents []AgentSnapshot, x, y, width int) {
 	// Draw background
 	vector.DrawFilledRect(screen, float32(x), float32(y), float32(width), float32(agentHeaderHeight),
 		color.RGBA{R: 0x1A, G: 0x1A, B: 0x2E, A: 0xFF}, false)
@@ -93,8 +98,8 @@ func (r *Renderer) drawHeader(screen *ebiten.Image, agents []*Agent, x, y, width
 	statusCounts := make(map[AgentStatus]int)
 	var totalTokens int64
 	for _, agent := range agents {
-		statusCounts[agent.Status()]++
-		totalTokens += agent.TokensUsed()
+		statusCounts[agent.Status]++
+		totalTokens += agent.TokensUsed
 	}
 
 	// Draw status summary
@@ -132,9 +137,9 @@ func (r *Renderer) drawEmptyState(screen *ebiten.Image, x, y, width, height int)
 }
 
 // drawAgentCard renders a single agent as a card.
-func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
+func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent AgentSnapshot, x, y int) {
 	// Get color based on status
-	statusColor := statusColors[agent.Status()]
+	statusColor := statusColors[agent.Status]
 
 	// Draw card background
 	bgColor := color.RGBA{R: 0x2A, G: 0x2A, B: 0x3E, A: 0xFF}
@@ -147,16 +152,16 @@ func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
 
 	// Draw agent name
 	nameY := y + 8
-	ebitenutil.DebugPrintAt(screen, agent.Name(), x+8, nameY)
+	ebitenutil.DebugPrintAt(screen, agent.Name, x+8, nameY)
 
 	// Draw status indicator
 	statusY := y + 24
-	statusStr := fmt.Sprintf("[%s]", agent.Status())
+	statusStr := fmt.Sprintf("[%s]", agent.Status)
 	ebitenutil.DebugPrintAt(screen, statusStr, x+8, statusY)
 
 	// Draw current task (truncated)
 	taskY := y + 44
-	task := agent.CurrentTask()
+	task := agent.CurrentTask
 	if len(task) > 25 {
 		task = task[:22] + "..."
 	}
@@ -169,7 +174,7 @@ func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
 	usageY := y + 68
 	usageWidth := agentCardWidth - 16
 	usageHeight := 12
-	usage := clampUnitInterval(agent.ContextUsage())
+	usage := clampUnitInterval(agent.ContextUsage)
 
 	// Background
 	vector.DrawFilledRect(screen, float32(x+8), float32(usageY), float32(usageWidth), float32(usageHeight),
@@ -185,12 +190,12 @@ func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
 
 	// Draw usage percentage
 	usageLabelY := y + 84
-	usageLabel := fmt.Sprintf("Context: %.0f%% | Files: %d", usage*100, agent.FileCount())
+	usageLabel := fmt.Sprintf("Context: %.0f%% | Files: %d", usage*100, agent.FileCount)
 	ebitenutil.DebugPrintAt(screen, usageLabel, x+8, usageLabelY)
 
 	// Draw tokens used
 	tokensY := y + 100
-	tokensLabel := fmt.Sprintf("Tokens: %dk / %dk", agent.TokensUsed()/1000, agent.TokenLimit()/1000)
+	tokensLabel := fmt.Sprintf("Tokens: %dk / %dk", agent.TokensUsed/1000, agent.TokenLimit/1000)
 	ebitenutil.DebugPrintAt(screen, tokensLabel, x+8, tokensY)
 }
 

--- a/internal/production/watcher.go
+++ b/internal/production/watcher.go
@@ -18,6 +18,25 @@ import (
 // be registered before starting the watcher to avoid potential races where a discoverer
 // is added mid-poll. This is by design - registering discoverers at startup is the
 // expected usage pattern.
+//
+// # Concurrency
+//
+// mu protects: registry, pollInterval, running, stopCh, newTicker.
+// fileTimesMu protects: fileTimes.
+//
+// Goroutines:
+// - poll: started by Start, exits when stopCh is closed.
+//
+// Channel: stopCh (chan struct{})
+// - Created by: Start
+// - Closed by: Stop
+// - Read by: poll
+//
+// # State machine
+//
+// Idle -> Running -> Stopped
+// Start is idempotent; Stop is idempotent. A watcher may be restarted after Stop,
+// which creates a new stopCh and poll goroutine.
 type Watcher struct {
 	mu sync.Mutex
 
@@ -31,6 +50,14 @@ type Watcher struct {
 	// File modification times for change detection
 	fileTimesMu sync.Mutex
 	fileTimes   map[string]time.Time
+}
+
+// WatcherSnapshot is an immutable, point-in-time view of watcher state.
+// Modifying the snapshot does not affect the underlying watcher.
+type WatcherSnapshot struct {
+	Running      bool
+	PollInterval time.Duration
+	TrackedPaths int
 }
 
 type ticker interface {
@@ -127,6 +154,24 @@ func (w *Watcher) IsRunning() bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.running
+}
+
+// Snapshot returns an immutable, point-in-time view of watcher state.
+func (w *Watcher) Snapshot() WatcherSnapshot {
+	w.mu.Lock()
+	running := w.running
+	pollInterval := w.pollInterval
+	w.mu.Unlock()
+
+	w.fileTimesMu.Lock()
+	tracked := len(w.fileTimes)
+	w.fileTimesMu.Unlock()
+
+	return WatcherSnapshot{
+		Running:      running,
+		PollInterval: pollInterval,
+		TrackedPaths: tracked,
+	}
 }
 
 // poll is the main polling loop.


### PR DESCRIPTION
## Summary
- document concurrency invariants/state transitions for harness, watchers, agents, orchestrator, and debug sessions
- add snapshot types for read-only access, plus session/agent snapshots
- use agent snapshots in the multiagent renderer to avoid repeated locking

## Testing
- `nix develop --command go fmt ./...`
- `nix develop --command bazel build //...`
- `xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test //...` (fails: race_verification_test expects race flag)
- `xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...`