### PR TITLE
P5.3: Extract shared renderer patterns

### DIFF
--- a/internal/capability/BUILD.bazel
+++ b/internal/capability/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/tedks/CodingGame/internal/capability",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/ui",
         "@com_github_hajimehoshi_ebiten_v2//:ebiten",
         "@com_github_hajimehoshi_ebiten_v2//ebitenutil",
         "@com_github_hajimehoshi_ebiten_v2//vector",

--- a/internal/capability/renderer.go
+++ b/internal/capability/renderer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/vector"
+	"github.com/tedks/CodingGame/internal/ui"
 )
 
 // Renderer draws the capability inventory (tech tree view).
@@ -181,23 +182,12 @@ func (r *Renderer) drawCapabilityNode(screen *ebiten.Image, cap *Capability, x, 
 	if !cap.Enabled {
 		bgColor = color.RGBA{30, 30, 30, 200}
 	}
-	vector.DrawFilledRect(
-		screen,
-		float32(x), float32(y),
-		float32(width), float32(r.nodeHeight),
-		bgColor,
-		false,
-	)
-
-	// Left border accent by type
 	accentColor := r.getTypeColor(cap.Type)
-	vector.DrawFilledRect(
-		screen,
-		float32(x), float32(y),
-		4, float32(r.nodeHeight),
-		accentColor,
-		false,
-	)
+	ui.DrawCard(screen, x, y, width, r.nodeHeight, ui.CardStyle{
+		Background:  bgColor,
+		AccentWidth: 4,
+		AccentColor: accentColor,
+	})
 
 	// Name (top line)
 	nameY := y + 6

--- a/internal/multiagent/BUILD.bazel
+++ b/internal/multiagent/BUILD.bazel
@@ -10,9 +10,9 @@ go_library(
     importpath = "github.com/tedks/CodingGame/internal/multiagent",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/ui",
         "@com_github_hajimehoshi_ebiten_v2//:ebiten",
         "@com_github_hajimehoshi_ebiten_v2//ebitenutil",
-        "@com_github_hajimehoshi_ebiten_v2//vector",
     ],
 )
 

--- a/internal/multiagent/renderer.go
+++ b/internal/multiagent/renderer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
-	"github.com/hajimehoshi/ebiten/v2/vector"
+	"github.com/tedks/CodingGame/internal/ui"
 )
 
 // Renderer draws the multi-agent orchestration UI.
@@ -20,12 +20,10 @@ func NewRenderer() *Renderer {
 
 // Layout constants
 const (
-	agentPadding      = 20
-	agentCardWidth    = 200
-	agentCardHeight   = 120
-	agentCardSpacing  = 20
-	agentCardsPerRow  = 4
-	agentHeaderHeight = 60
+	agentCardWidth   = 200
+	agentCardHeight  = 120
+	agentCardSpacing = 20
+	agentCardsPerRow = 4
 )
 
 // Color scheme for agent statuses
@@ -44,22 +42,25 @@ var statusColors = map[AgentStatus]color.RGBA{
 //   - x, y: the top-left position to start drawing
 //   - width, height: the available drawing area
 func (r *Renderer) Draw(screen *ebiten.Image, agents []*Agent, x, y, width, height int) {
+	headerLayout := ui.DefaultHeaderLayout()
+
 	// Draw header with summary
-	r.drawHeader(screen, agents, x, y, width)
+	r.drawHeader(screen, agents, x, y, width, headerLayout)
 
 	// If no agents, show empty state
 	if len(agents) == 0 {
-		r.drawEmptyState(screen, x, y+agentHeaderHeight, width, height-agentHeaderHeight)
+		ui.DrawEmptyState(screen, "No active agents", "Agents will appear here when active",
+			x, y+headerLayout.Height, width, height-headerLayout.Height)
 		return
 	}
 
 	// Draw agents as cards
-	startY := y + agentHeaderHeight + agentPadding
+	startY := y + headerLayout.Height + headerLayout.Padding
 	for i, agent := range agents {
 		row := i / agentCardsPerRow
 		col := i % agentCardsPerRow
 
-		cardX := x + agentPadding + col*(agentCardWidth+agentCardSpacing)
+		cardX := x + headerLayout.Padding + col*(agentCardWidth+agentCardSpacing)
 		cardY := startY + row*(agentCardHeight+agentCardSpacing)
 
 		// Check if we're still in bounds
@@ -72,22 +73,13 @@ func (r *Renderer) Draw(screen *ebiten.Image, agents []*Agent, x, y, width, heig
 }
 
 func tokenSummaryX(x, width int) (int, bool) {
-	tokenX := x + width - 200
-	minX := x + agentPadding
-	if tokenX < minX {
-		return minX, false
-	}
-	return tokenX, true
+	layout := ui.DefaultHeaderLayout()
+	return ui.RightAlignedSummaryX(x, width, 200, layout.Padding)
 }
 
 // drawHeader renders the summary header.
-func (r *Renderer) drawHeader(screen *ebiten.Image, agents []*Agent, x, y, width int) {
-	// Draw background
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(width), float32(agentHeaderHeight),
-		color.RGBA{R: 0x1A, G: 0x1A, B: 0x2E, A: 0xFF}, false)
-
-	// Draw title
-	ebitenutil.DebugPrintAt(screen, "MULTI-AGENT ORCHESTRATOR", x+agentPadding, y+10)
+func (r *Renderer) drawHeader(screen *ebiten.Image, agents []*Agent, x, y, width int, layout ui.HeaderLayout) {
+	ui.DrawHeader(screen, "MULTI-AGENT ORCHESTRATOR", x, y, width, layout)
 
 	// Calculate status summary
 	statusCounts := make(map[AgentStatus]int)
@@ -98,15 +90,14 @@ func (r *Renderer) drawHeader(screen *ebiten.Image, agents []*Agent, x, y, width
 	}
 
 	// Draw status summary
-	summaryY := y + 30
-	summaryX := x + agentPadding
+	summaryY := y + layout.SummaryOffsetY
 	working := statusCounts[StatusWorking]
 	idle := statusCounts[StatusIdle]
 	paused := statusCounts[StatusPaused]
 
 	summary := fmt.Sprintf("Agents: %d | Working: %d | Idle: %d | Paused: %d",
 		len(agents), working, idle, paused)
-	ebitenutil.DebugPrintAt(screen, summary, summaryX, summaryY)
+	ui.DrawHeaderSummary(screen, summary, x, y, layout)
 
 	// Draw token usage
 	tokenX, ok := tokenSummaryX(x, width)
@@ -116,34 +107,13 @@ func (r *Renderer) drawHeader(screen *ebiten.Image, agents []*Agent, x, y, width
 	}
 }
 
-// drawEmptyState renders a message when no agents are active.
-func (r *Renderer) drawEmptyState(screen *ebiten.Image, x, y, width, height int) {
-	msg := "No active agents"
-	hint := "Agents will appear here when active"
-
-	// Center the messages
-	msgX := x + width/2 - len(msg)*3
-	msgY := y + height/2 - 20
-	hintX := x + width/2 - len(hint)*3
-	hintY := y + height/2
-
-	ebitenutil.DebugPrintAt(screen, msg, msgX, msgY)
-	ebitenutil.DebugPrintAt(screen, hint, hintX, hintY)
-}
-
 // drawAgentCard renders a single agent as a card.
 func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
 	// Get color based on status
 	statusColor := statusColors[agent.Status()]
 
 	// Draw card background
-	bgColor := color.RGBA{R: 0x2A, G: 0x2A, B: 0x3E, A: 0xFF}
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(agentCardWidth), float32(agentCardHeight),
-		bgColor, false)
-
-	// Draw status indicator border
-	vector.StrokeRect(screen, float32(x), float32(y), float32(agentCardWidth), float32(agentCardHeight),
-		2, statusColor, false)
+	ui.DrawCard(screen, x, y, agentCardWidth, agentCardHeight, ui.DefaultCardStyle(statusColor))
 
 	// Draw agent name
 	nameY := y + 8
@@ -171,17 +141,10 @@ func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
 	usageHeight := 12
 	usage := clampUnitInterval(agent.ContextUsage())
 
-	// Background
-	vector.DrawFilledRect(screen, float32(x+8), float32(usageY), float32(usageWidth), float32(usageHeight),
-		color.RGBA{R: 0x40, G: 0x40, B: 0x40, A: 0xFF}, false)
-
 	// Fill based on usage
 	usageColor := getUsageColor(usage)
-	fillWidth := int(float64(usageWidth) * usage)
-	if fillWidth > 0 {
-		vector.DrawFilledRect(screen, float32(x+8), float32(usageY), float32(fillWidth), float32(usageHeight),
-			usageColor, false)
-	}
+	ui.DrawProgressBar(screen, x+8, usageY, usageWidth, usageHeight, usage,
+		color.RGBA{R: 0x40, G: 0x40, B: 0x40, A: 0xFF}, usageColor)
 
 	// Draw usage percentage
 	usageLabelY := y + 84

--- a/internal/multiagent/renderer_test.go
+++ b/internal/multiagent/renderer_test.go
@@ -2,6 +2,8 @@ package multiagent
 
 import (
 	"testing"
+
+	"github.com/tedks/CodingGame/internal/ui"
 )
 
 func TestNewRenderer(t *testing.T) {
@@ -44,8 +46,8 @@ func TestLayoutConstants(t *testing.T) {
 	if agentCardsPerRow <= 0 {
 		t.Error("agentCardsPerRow should be positive")
 	}
-	if agentHeaderHeight <= 0 {
-		t.Error("agentHeaderHeight should be positive")
+	if ui.DefaultHeaderLayout().Height <= 0 {
+		t.Error("default header height should be positive")
 	}
 }
 

--- a/internal/production/BUILD.bazel
+++ b/internal/production/BUILD.bazel
@@ -12,9 +12,9 @@ go_library(
     importpath = "github.com/tedks/CodingGame/internal/production",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/ui",
         "@com_github_hajimehoshi_ebiten_v2//:ebiten",
         "@com_github_hajimehoshi_ebiten_v2//ebitenutil",
-        "@com_github_hajimehoshi_ebiten_v2//vector",
     ],
 )
 

--- a/internal/production/renderer.go
+++ b/internal/production/renderer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
-	"github.com/hajimehoshi/ebiten/v2/vector"
+	"github.com/tedks/CodingGame/internal/ui"
 )
 
 // Renderer draws the production environment visualization.
@@ -20,12 +20,10 @@ func NewRenderer() *Renderer {
 
 // Layout constants
 const (
-	prodPadding      = 20
 	prodCityWidth    = 180
 	prodCityHeight   = 100
 	prodCitySpacing  = 30
 	prodCitiesPerRow = 4
-	prodHeaderHeight = 60
 )
 
 // Color scheme for health statuses
@@ -43,22 +41,26 @@ var healthColors = map[HealthStatus]color.RGBA{
 //   - x, y: the top-left position to start drawing
 //   - width, height: the available drawing area
 func (r *Renderer) Draw(screen *ebiten.Image, services []*Service, x, y, width, height int) {
+	headerLayout := ui.DefaultHeaderLayout()
+
 	// Draw header with summary
-	r.drawHeader(screen, services, x, y, width)
+	r.drawHeader(screen, services, x, y, width, headerLayout)
 
 	// If no services, show empty state
 	if len(services) == 0 {
-		r.drawEmptyState(screen, x, y+prodHeaderHeight, width, height-prodHeaderHeight)
+		ui.DrawEmptyState(screen, "No production services configured",
+			"Add a .production.json file to monitor services",
+			x, y+headerLayout.Height, width, height-headerLayout.Height)
 		return
 	}
 
 	// Draw services as cities
-	startY := y + prodHeaderHeight + prodPadding
+	startY := y + headerLayout.Height + headerLayout.Padding
 	for i, svc := range services {
 		row := i / prodCitiesPerRow
 		col := i % prodCitiesPerRow
 
-		cityX := x + prodPadding + col*(prodCityWidth+prodCitySpacing)
+		cityX := x + headerLayout.Padding + col*(prodCityWidth+prodCitySpacing)
 		cityY := startY + row*(prodCityHeight+prodCitySpacing)
 
 		// Check if we're still in bounds
@@ -71,22 +73,13 @@ func (r *Renderer) Draw(screen *ebiten.Image, services []*Service, x, y, width, 
 }
 
 func weatherSummaryX(x, width int) (int, bool) {
-	weatherX := x + width - 300
-	minX := x + prodPadding
-	if weatherX < minX {
-		return minX, false
-	}
-	return weatherX, true
+	layout := ui.DefaultHeaderLayout()
+	return ui.RightAlignedSummaryX(x, width, 300, layout.Padding)
 }
 
 // drawHeader renders the summary header with weather overview.
-func (r *Renderer) drawHeader(screen *ebiten.Image, services []*Service, x, y, width int) {
-	// Draw background
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(width), float32(prodHeaderHeight),
-		color.RGBA{R: 0x1A, G: 0x1A, B: 0x2E, A: 0xFF}, false)
-
-	// Draw title
-	ebitenutil.DebugPrintAt(screen, "PRODUCTION REALM", x+prodPadding, y+10)
+func (r *Renderer) drawHeader(screen *ebiten.Image, services []*Service, x, y, width int, layout ui.HeaderLayout) {
+	ui.DrawHeader(screen, "PRODUCTION REALM", x, y, width, layout)
 
 	// Calculate health summary
 	healthCounts := make(map[HealthStatus]int)
@@ -97,15 +90,14 @@ func (r *Renderer) drawHeader(screen *ebiten.Image, services []*Service, x, y, w
 	}
 
 	// Draw health summary
-	summaryY := y + 30
-	summaryX := x + prodPadding
+	summaryY := y + layout.SummaryOffsetY
 	healthy := healthCounts[HealthHealthy]
 	degraded := healthCounts[HealthDegraded]
 	unhealthy := healthCounts[HealthUnhealthy]
 
 	summary := fmt.Sprintf("Services: %d | Healthy: %d | Degraded: %d | Unhealthy: %d",
 		len(services), healthy, degraded, unhealthy)
-	ebitenutil.DebugPrintAt(screen, summary, summaryX, summaryY)
+	ui.DrawHeaderSummary(screen, summary, x, y, layout)
 
 	// Draw weather summary
 	weatherX, ok := weatherSummaryX(x, width)
@@ -116,34 +108,13 @@ func (r *Renderer) drawHeader(screen *ebiten.Image, services []*Service, x, y, w
 	}
 }
 
-// drawEmptyState renders a message when no services are configured.
-func (r *Renderer) drawEmptyState(screen *ebiten.Image, x, y, width, height int) {
-	msg := "No production services configured"
-	hint := "Add a .production.json file to monitor services"
-
-	// Center the messages
-	msgX := x + width/2 - len(msg)*3
-	msgY := y + height/2 - 20
-	hintX := x + width/2 - len(hint)*3
-	hintY := y + height/2
-
-	ebitenutil.DebugPrintAt(screen, msg, msgX, msgY)
-	ebitenutil.DebugPrintAt(screen, hint, hintX, hintY)
-}
-
 // drawCity renders a single service as a "city" card.
 func (r *Renderer) drawCity(screen *ebiten.Image, svc *Service, x, y int) {
 	// Get color based on health
 	healthColor := healthColors[svc.Health]
 
 	// Draw city background
-	bgColor := color.RGBA{R: 0x2A, G: 0x2A, B: 0x3E, A: 0xFF}
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(prodCityWidth), float32(prodCityHeight),
-		bgColor, false)
-
-	// Draw health indicator border
-	vector.StrokeRect(screen, float32(x), float32(y), float32(prodCityWidth), float32(prodCityHeight),
-		2, healthColor, false)
+	ui.DrawCard(screen, x, y, prodCityWidth, prodCityHeight, ui.DefaultCardStyle(healthColor))
 
 	// Draw service name
 	nameY := y + 8

--- a/internal/production/renderer_test.go
+++ b/internal/production/renderer_test.go
@@ -2,6 +2,8 @@ package production
 
 import (
 	"testing"
+
+	"github.com/tedks/CodingGame/internal/ui"
 )
 
 func TestNewRenderer(t *testing.T) {
@@ -93,8 +95,8 @@ func TestLayoutConstants(t *testing.T) {
 	if prodCitiesPerRow <= 0 {
 		t.Error("prodCitiesPerRow should be positive")
 	}
-	if prodHeaderHeight <= 0 {
-		t.Error("prodHeaderHeight should be positive")
+	if ui.DefaultHeaderLayout().Height <= 0 {
+		t.Error("default header height should be positive")
 	}
 }
 

--- a/internal/ui/BUILD.bazel
+++ b/internal/ui/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "ui",
     srcs = [
+        "components.go",
         "menu.go",
         "prompt.go",
         "scene.go",

--- a/internal/ui/components.go
+++ b/internal/ui/components.go
@@ -1,0 +1,157 @@
+package ui
+
+import (
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+// HeaderLayout defines shared spacing and background styling for renderer headers.
+type HeaderLayout struct {
+	Height         int
+	Padding        int
+	TitleOffsetY   int
+	SummaryOffsetY int
+	Background     color.RGBA
+}
+
+// DefaultHeaderLayout returns the shared header layout used by renderer summaries.
+func DefaultHeaderLayout() HeaderLayout {
+	return HeaderLayout{
+		Height:         60,
+		Padding:        20,
+		TitleOffsetY:   10,
+		SummaryOffsetY: 30,
+		Background:     color.RGBA{R: 0x1A, G: 0x1A, B: 0x2E, A: 0xFF},
+	}
+}
+
+// DrawHeader draws a standard renderer header background and title.
+func DrawHeader(screen *ebiten.Image, title string, x, y, width int, layout HeaderLayout) {
+	DrawHeaderBackground(screen, x, y, width, layout)
+	DrawHeaderTitle(screen, title, x, y, layout)
+}
+
+// DrawHeaderBackground draws the background bar for a header.
+func DrawHeaderBackground(screen *ebiten.Image, x, y, width int, layout HeaderLayout) {
+	vector.DrawFilledRect(
+		screen,
+		float32(x), float32(y),
+		float32(width), float32(layout.Height),
+		layout.Background,
+		false,
+	)
+}
+
+// DrawHeaderTitle draws the title text within a header.
+func DrawHeaderTitle(screen *ebiten.Image, title string, x, y int, layout HeaderLayout) {
+	ebitenutil.DebugPrintAt(screen, title, x+layout.Padding, y+layout.TitleOffsetY)
+}
+
+// DrawHeaderSummary draws a left-aligned summary line in a header.
+func DrawHeaderSummary(screen *ebiten.Image, summary string, x, y int, layout HeaderLayout) {
+	ebitenutil.DebugPrintAt(screen, summary, x+layout.Padding, y+layout.SummaryOffsetY)
+}
+
+// RightAlignedSummaryX returns the starting X for a right-aligned header summary block.
+func RightAlignedSummaryX(x, width, blockWidth, minPadding int) (int, bool) {
+	startX := x + width - blockWidth
+	minX := x + minPadding
+	if startX < minX {
+		return minX, false
+	}
+	return startX, true
+}
+
+// CardStyle defines shared styling for card-like panels.
+type CardStyle struct {
+	Background  color.RGBA
+	BorderColor color.RGBA
+	BorderWidth float32
+	AccentWidth int
+	AccentColor color.RGBA
+}
+
+// DefaultCardStyle returns a shared card style with standard background and border width.
+func DefaultCardStyle(borderColor color.RGBA) CardStyle {
+	return CardStyle{
+		Background:  color.RGBA{R: 0x2A, G: 0x2A, B: 0x3E, A: 0xFF},
+		BorderColor: borderColor,
+		BorderWidth: 2,
+	}
+}
+
+// DrawCard draws a card-like panel with optional border and accent.
+func DrawCard(screen *ebiten.Image, x, y, width, height int, style CardStyle) {
+	vector.DrawFilledRect(
+		screen,
+		float32(x), float32(y),
+		float32(width), float32(height),
+		style.Background,
+		false,
+	)
+
+	if style.AccentWidth > 0 {
+		vector.DrawFilledRect(
+			screen,
+			float32(x), float32(y),
+			float32(style.AccentWidth), float32(height),
+			style.AccentColor,
+			false,
+		)
+	}
+
+	if style.BorderWidth > 0 {
+		vector.StrokeRect(
+			screen,
+			float32(x), float32(y),
+			float32(width), float32(height),
+			style.BorderWidth,
+			style.BorderColor,
+			false,
+		)
+	}
+}
+
+// DrawEmptyState centers a message and hint for empty renderer content.
+func DrawEmptyState(screen *ebiten.Image, message, hint string, x, y, width, height int) {
+	const approxCharWidth = 3
+	msgX := x + width/2 - len(message)*approxCharWidth
+	msgY := y + height/2 - 20
+	hintX := x + width/2 - len(hint)*approxCharWidth
+	hintY := y + height/2
+
+	ebitenutil.DebugPrintAt(screen, message, msgX, msgY)
+	ebitenutil.DebugPrintAt(screen, hint, hintX, hintY)
+}
+
+// DrawProgressBar draws a simple horizontal progress bar.
+func DrawProgressBar(screen *ebiten.Image, x, y, width, height int, progress float64, background, fill color.RGBA) {
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 1 {
+		progress = 1
+	}
+
+	vector.DrawFilledRect(
+		screen,
+		float32(x), float32(y),
+		float32(width), float32(height),
+		background,
+		false,
+	)
+
+	fillWidth := int(float64(width) * progress)
+	if fillWidth > 0 {
+		vector.DrawFilledRect(
+			screen,
+			float32(x), float32(y),
+			float32(fillWidth), float32(height),
+			fill,
+			false,
+		)
+	}
+}


### PR DESCRIPTION
## Summary
- add shared ui renderer components for headers, cards, progress bars, and empty states
- refactor multiagent/production header + card rendering to use shared helpers
- reuse shared card drawing for capability nodes

## Testing
- nix develop --command go fmt ./...
- nix develop --command bazel build //...
- xvfb-run -a -s "-screen 0 1024x768x24 -ac" nix develop --command bazel test --@io_bazel_rules_go//go/config:race //...