### PR TITLE
P5.2: Centralize layout/theme constants

### DIFF
--- a/internal/capability/BUILD.bazel
+++ b/internal/capability/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "@com_github_hajimehoshi_ebiten_v2//:ebiten",
         "@com_github_hajimehoshi_ebiten_v2//ebitenutil",
         "@com_github_hajimehoshi_ebiten_v2//vector",
+        "//internal/theme",
     ],
 )
 

--- a/internal/capability/renderer.go
+++ b/internal/capability/renderer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/vector"
+	"github.com/tedks/CodingGame/internal/theme"
 )
 
 // Renderer draws the capability inventory (tech tree view).
@@ -38,27 +39,27 @@ type Renderer struct {
 func NewRenderer() *Renderer {
 	return &Renderer{
 		// Domain colors (column headers)
-		coreColor:        color.RGBA{60, 80, 100, 255},
-		buildColor:       color.RGBA{80, 100, 60, 255},
-		versionCtrlColor: color.RGBA{100, 80, 60, 255},
-		deploymentColor:  color.RGBA{80, 60, 100, 255},
-		analysisColor:    color.RGBA{60, 100, 80, 255},
+		coreColor:        theme.CapabilityDomainCore,
+		buildColor:       theme.CapabilityDomainBuild,
+		versionCtrlColor: theme.CapabilityDomainVersionCtrl,
+		deploymentColor:  theme.CapabilityDomainDeployment,
+		analysisColor:    theme.CapabilityDomainAnalysis,
 
 		// Type colors (node border accents)
-		toolColor:        color.RGBA{100, 180, 255, 255},
-		mcpColor:         color.RGBA{255, 180, 100, 255},
-		commandColor:     color.RGBA{180, 100, 255, 255},
-		integrationColor: color.RGBA{100, 255, 180, 255},
+		toolColor:        theme.CapabilityTypeTool,
+		mcpColor:         theme.CapabilityTypeMCP,
+		commandColor:     theme.CapabilityTypeCommand,
+		integrationColor: theme.CapabilityTypeIntegration,
 
 		// Background
-		backgroundColor: color.RGBA{20, 25, 30, 255},
+		backgroundColor: theme.CapabilityBackground,
 
 		// Layout
-		columnWidth:  200,
-		nodeHeight:   40,
-		nodeMargin:   8,
-		headerHeight: 30,
-		padding:      16,
+		columnWidth:  theme.CapabilityColumnWidth,
+		nodeHeight:   theme.CapabilityNodeHeight,
+		nodeMargin:   theme.CapabilityNodeMargin,
+		headerHeight: theme.CapabilityHeaderHeight,
+		padding:      theme.CapabilityPadding,
 	}
 }
 
@@ -105,7 +106,7 @@ func (r *Renderer) Draw(screen *ebiten.Image, capabilities []*Capability, x, y, 
 	}
 
 	// Draw legend at bottom
-	r.drawLegend(screen, x+r.padding, y+height-40, width-2*r.padding)
+	r.drawLegend(screen, x+r.padding, y+height-theme.CapabilityLegendHeight, width-2*r.padding)
 }
 
 func (r *Renderer) columnLayout(width, height int, domains []Domain) (startYOffset, columnWidth, columnHeight int, ok bool) {
@@ -129,7 +130,7 @@ func (r *Renderer) columnLayout(width, height int, domains []Domain) (startYOffs
 		return 0, 0, 0, false
 	}
 
-	startYOffset = r.padding + 20 + r.padding
+	startYOffset = r.padding + theme.CapabilityTitleHeight + r.padding
 	columnHeight = height - startYOffset - r.padding
 	if columnHeight <= 0 {
 		return 0, 0, 0, false
@@ -152,8 +153,8 @@ func (r *Renderer) drawDomainColumn(screen *ebiten.Image, domain Domain, capabil
 
 	// Draw domain name centered in header
 	domainName := domain.String()
-	textX := x + (width-len(domainName)*7)/2 // Approximate centering (7px per char)
-	textY := y + (r.headerHeight-14)/2       // 14px line height
+	textX := theme.CenterTextX(x, width, domainName, theme.CapabilityHeaderCharWidth)
+	textY := theme.CenterTextY(y, r.headerHeight, theme.CapabilityHeaderLineHeight)
 	ebitenutil.DebugPrintAt(screen, domainName, textX, textY)
 
 	// Draw capability nodes
@@ -161,7 +162,7 @@ func (r *Renderer) drawDomainColumn(screen *ebiten.Image, domain Domain, capabil
 	for _, cap := range capabilities {
 		if nodeY+r.nodeHeight > y+maxHeight {
 			// No more space, draw overflow indicator
-			ebitenutil.DebugPrintAt(screen, "...", x+width/2-10, nodeY)
+			ebitenutil.DebugPrintAt(screen, "...", theme.CenterTextX(x, width, "...", theme.CapabilityHeaderCharWidth), nodeY)
 			break
 		}
 		r.drawCapabilityNode(screen, cap, x, nodeY, width)
@@ -170,16 +171,16 @@ func (r *Renderer) drawDomainColumn(screen *ebiten.Image, domain Domain, capabil
 
 	// Show count if empty
 	if len(capabilities) == 0 {
-		ebitenutil.DebugPrintAt(screen, "(none)", x+width/2-20, y+r.headerHeight+r.nodeMargin)
+		ebitenutil.DebugPrintAt(screen, "(none)", theme.CenterTextX(x, width, "(none)", theme.CapabilityHeaderCharWidth), y+r.headerHeight+r.nodeMargin)
 	}
 }
 
 // drawCapabilityNode draws a single capability.
 func (r *Renderer) drawCapabilityNode(screen *ebiten.Image, cap *Capability, x, y, width int) {
 	// Background
-	bgColor := color.RGBA{40, 45, 50, 255}
+	bgColor := theme.CapabilityNodeBackground
 	if !cap.Enabled {
-		bgColor = color.RGBA{30, 30, 30, 200}
+		bgColor = theme.CapabilityNodeDisabled
 	}
 	vector.DrawFilledRect(
 		screen,
@@ -194,19 +195,19 @@ func (r *Renderer) drawCapabilityNode(screen *ebiten.Image, cap *Capability, x, 
 	vector.DrawFilledRect(
 		screen,
 		float32(x), float32(y),
-		4, float32(r.nodeHeight),
+		float32(theme.CapabilityNodeAccentWidth), float32(r.nodeHeight),
 		accentColor,
 		false,
 	)
 
 	// Name (top line)
-	nameY := y + 6
-	ebitenutil.DebugPrintAt(screen, cap.Name, x+r.nodeMargin+4, nameY)
+	nameY := y + theme.CapabilityNodeNameOffsetY
+	ebitenutil.DebugPrintAt(screen, cap.Name, x+r.nodeMargin+theme.CapabilityNodeAccentWidth, nameY)
 
 	// Type indicator (smaller, below name)
 	typeText := cap.Type.String()
-	typeY := y + 22
-	ebitenutil.DebugPrintAt(screen, typeText, x+r.nodeMargin+4, typeY)
+	typeY := y + theme.CapabilityNodeTypeOffsetY
+	ebitenutil.DebugPrintAt(screen, typeText, x+r.nodeMargin+theme.CapabilityNodeAccentWidth, typeY)
 }
 
 // drawLegend draws the type color legend.
@@ -226,14 +227,14 @@ func (r *Renderer) drawLegend(screen *ebiten.Image, x, y, _ int) {
 		// Color swatch
 		vector.DrawFilledRect(
 			screen,
-			float32(currentX), float32(y+2),
-			10, 10,
+			float32(currentX), float32(y+theme.CapabilityLegendSwatchYOffset),
+			float32(theme.CapabilityLegendSwatchSize), float32(theme.CapabilityLegendSwatchSize),
 			item.color,
 			false,
 		)
 		// Label
-		ebitenutil.DebugPrintAt(screen, item.name, currentX+14, y)
-		currentX += len(item.name)*7 + 30
+		ebitenutil.DebugPrintAt(screen, item.name, currentX+theme.CapabilityLegendTextOffsetX, y)
+		currentX += len(item.name)*theme.CapabilityHeaderCharWidth + theme.CapabilityLegendItemSpacing
 	}
 }
 

--- a/internal/multiagent/BUILD.bazel
+++ b/internal/multiagent/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "@com_github_hajimehoshi_ebiten_v2//:ebiten",
         "@com_github_hajimehoshi_ebiten_v2//ebitenutil",
         "@com_github_hajimehoshi_ebiten_v2//vector",
+        "//internal/theme",
     ],
 )
 

--- a/internal/multiagent/renderer.go
+++ b/internal/multiagent/renderer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/vector"
+	"github.com/tedks/CodingGame/internal/theme"
 )
 
 // Renderer draws the multi-agent orchestration UI.
@@ -18,23 +19,13 @@ func NewRenderer() *Renderer {
 	return &Renderer{}
 }
 
-// Layout constants
-const (
-	agentPadding      = 20
-	agentCardWidth    = 200
-	agentCardHeight   = 120
-	agentCardSpacing  = 20
-	agentCardsPerRow  = 4
-	agentHeaderHeight = 60
-)
-
 // Color scheme for agent statuses
 var statusColors = map[AgentStatus]color.RGBA{
-	StatusIdle:      {R: 0x75, G: 0x75, B: 0x75, A: 0xFF}, // Gray
-	StatusWorking:   {R: 0x2E, G: 0x7D, B: 0x32, A: 0xFF}, // Green
-	StatusPaused:    {R: 0xF5, G: 0x7F, B: 0x17, A: 0xFF}, // Orange
-	StatusCompleted: {R: 0x19, G: 0x76, B: 0xD2, A: 0xFF}, // Blue
-	StatusError:     {R: 0xC6, G: 0x28, B: 0x28, A: 0xFF}, // Red
+	StatusIdle:      theme.StatusNeutral,
+	StatusWorking:   theme.StatusSuccess,
+	StatusPaused:    theme.StatusWarning,
+	StatusCompleted: theme.StatusInfo,
+	StatusError:     theme.StatusError,
 }
 
 // Draw renders the multi-agent orchestration view.
@@ -49,21 +40,21 @@ func (r *Renderer) Draw(screen *ebiten.Image, agents []*Agent, x, y, width, heig
 
 	// If no agents, show empty state
 	if len(agents) == 0 {
-		r.drawEmptyState(screen, x, y+agentHeaderHeight, width, height-agentHeaderHeight)
+		r.drawEmptyState(screen, x, y+theme.PanelHeaderHeight, width, height-theme.PanelHeaderHeight)
 		return
 	}
 
 	// Draw agents as cards
-	startY := y + agentHeaderHeight + agentPadding
+	startY := y + theme.PanelHeaderHeight + theme.PanelPadding
 	for i, agent := range agents {
-		row := i / agentCardsPerRow
-		col := i % agentCardsPerRow
+		row := i / theme.MultiAgentCardsPerRow
+		col := i % theme.MultiAgentCardsPerRow
 
-		cardX := x + agentPadding + col*(agentCardWidth+agentCardSpacing)
-		cardY := startY + row*(agentCardHeight+agentCardSpacing)
+		cardX := x + theme.PanelPadding + col*(theme.MultiAgentCardWidth+theme.MultiAgentCardSpacing)
+		cardY := startY + row*(theme.MultiAgentCardHeight+theme.MultiAgentCardSpacing)
 
 		// Check if we're still in bounds
-		if cardY+agentCardHeight > y+height {
+		if cardY+theme.MultiAgentCardHeight > y+height {
 			break
 		}
 
@@ -72,22 +63,17 @@ func (r *Renderer) Draw(screen *ebiten.Image, agents []*Agent, x, y, width, heig
 }
 
 func tokenSummaryX(x, width int) (int, bool) {
-	tokenX := x + width - 200
-	minX := x + agentPadding
-	if tokenX < minX {
-		return minX, false
-	}
-	return tokenX, true
+	return theme.RightAlignedX(x, width, theme.MultiAgentTokenSummaryWidth, theme.PanelPadding)
 }
 
 // drawHeader renders the summary header.
 func (r *Renderer) drawHeader(screen *ebiten.Image, agents []*Agent, x, y, width int) {
 	// Draw background
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(width), float32(agentHeaderHeight),
-		color.RGBA{R: 0x1A, G: 0x1A, B: 0x2E, A: 0xFF}, false)
+	vector.DrawFilledRect(screen, float32(x), float32(y), float32(width), float32(theme.PanelHeaderHeight),
+		theme.HeaderBackground, false)
 
 	// Draw title
-	ebitenutil.DebugPrintAt(screen, "MULTI-AGENT ORCHESTRATOR", x+agentPadding, y+10)
+	ebitenutil.DebugPrintAt(screen, "MULTI-AGENT ORCHESTRATOR", x+theme.PanelPadding, y+theme.PanelHeaderTitleOffsetY)
 
 	// Calculate status summary
 	statusCounts := make(map[AgentStatus]int)
@@ -98,8 +84,8 @@ func (r *Renderer) drawHeader(screen *ebiten.Image, agents []*Agent, x, y, width
 	}
 
 	// Draw status summary
-	summaryY := y + 30
-	summaryX := x + agentPadding
+	summaryY := y + theme.PanelHeaderSummaryOffsetY
+	summaryX := x + theme.PanelPadding
 	working := statusCounts[StatusWorking]
 	idle := statusCounts[StatusIdle]
 	paused := statusCounts[StatusPaused]
@@ -122,9 +108,9 @@ func (r *Renderer) drawEmptyState(screen *ebiten.Image, x, y, width, height int)
 	hint := "Agents will appear here when active"
 
 	// Center the messages
-	msgX := x + width/2 - len(msg)*3
-	msgY := y + height/2 - 20
-	hintX := x + width/2 - len(hint)*3
+	msgX := theme.CenterTextX(x, width, msg, theme.CompactTextCharWidth)
+	msgY := y + height/2 - theme.EmptyStateLineOffset
+	hintX := theme.CenterTextX(x, width, hint, theme.CompactTextCharWidth)
 	hintY := y + height/2
 
 	ebitenutil.DebugPrintAt(screen, msg, msgX, msgY)
@@ -137,25 +123,24 @@ func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
 	statusColor := statusColors[agent.Status()]
 
 	// Draw card background
-	bgColor := color.RGBA{R: 0x2A, G: 0x2A, B: 0x3E, A: 0xFF}
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(agentCardWidth), float32(agentCardHeight),
-		bgColor, false)
+	vector.DrawFilledRect(screen, float32(x), float32(y), float32(theme.MultiAgentCardWidth), float32(theme.MultiAgentCardHeight),
+		theme.CardBackground, false)
 
 	// Draw status indicator border
-	vector.StrokeRect(screen, float32(x), float32(y), float32(agentCardWidth), float32(agentCardHeight),
-		2, statusColor, false)
+	vector.StrokeRect(screen, float32(x), float32(y), float32(theme.MultiAgentCardWidth), float32(theme.MultiAgentCardHeight),
+		theme.CardBorderWidth, statusColor, false)
 
 	// Draw agent name
-	nameY := y + 8
-	ebitenutil.DebugPrintAt(screen, agent.Name(), x+8, nameY)
+	nameY := y + theme.MultiAgentNameOffsetY
+	ebitenutil.DebugPrintAt(screen, agent.Name(), x+theme.CardTextPadding, nameY)
 
 	// Draw status indicator
-	statusY := y + 24
+	statusY := y + theme.MultiAgentStatusOffsetY
 	statusStr := fmt.Sprintf("[%s]", agent.Status())
-	ebitenutil.DebugPrintAt(screen, statusStr, x+8, statusY)
+	ebitenutil.DebugPrintAt(screen, statusStr, x+theme.CardTextPadding, statusY)
 
 	// Draw current task (truncated)
-	taskY := y + 44
+	taskY := y + theme.MultiAgentTaskOffsetY
 	task := agent.CurrentTask()
 	if len(task) > 25 {
 		task = task[:22] + "..."
@@ -163,45 +148,45 @@ func (r *Renderer) drawAgentCard(screen *ebiten.Image, agent *Agent, x, y int) {
 	if task == "" {
 		task = "(no task assigned)"
 	}
-	ebitenutil.DebugPrintAt(screen, task, x+8, taskY)
+	ebitenutil.DebugPrintAt(screen, task, x+theme.CardTextPadding, taskY)
 
 	// Draw context usage bar
-	usageY := y + 68
-	usageWidth := agentCardWidth - 16
-	usageHeight := 12
+	usageY := y + theme.MultiAgentUsageOffsetY
+	usageWidth := theme.MultiAgentCardWidth - 2*theme.CardTextPadding
+	usageHeight := theme.MultiAgentUsageBarHeight
 	usage := clampUnitInterval(agent.ContextUsage())
 
 	// Background
-	vector.DrawFilledRect(screen, float32(x+8), float32(usageY), float32(usageWidth), float32(usageHeight),
-		color.RGBA{R: 0x40, G: 0x40, B: 0x40, A: 0xFF}, false)
+	vector.DrawFilledRect(screen, float32(x+theme.CardTextPadding), float32(usageY), float32(usageWidth), float32(usageHeight),
+		theme.UsageBarBackground, false)
 
 	// Fill based on usage
 	usageColor := getUsageColor(usage)
 	fillWidth := int(float64(usageWidth) * usage)
 	if fillWidth > 0 {
-		vector.DrawFilledRect(screen, float32(x+8), float32(usageY), float32(fillWidth), float32(usageHeight),
+		vector.DrawFilledRect(screen, float32(x+theme.CardTextPadding), float32(usageY), float32(fillWidth), float32(usageHeight),
 			usageColor, false)
 	}
 
 	// Draw usage percentage
-	usageLabelY := y + 84
+	usageLabelY := y + theme.MultiAgentUsageLabelOffsetY
 	usageLabel := fmt.Sprintf("Context: %.0f%% | Files: %d", usage*100, agent.FileCount())
-	ebitenutil.DebugPrintAt(screen, usageLabel, x+8, usageLabelY)
+	ebitenutil.DebugPrintAt(screen, usageLabel, x+theme.CardTextPadding, usageLabelY)
 
 	// Draw tokens used
-	tokensY := y + 100
+	tokensY := y + theme.MultiAgentTokensOffsetY
 	tokensLabel := fmt.Sprintf("Tokens: %dk / %dk", agent.TokensUsed()/1000, agent.TokenLimit()/1000)
-	ebitenutil.DebugPrintAt(screen, tokensLabel, x+8, tokensY)
+	ebitenutil.DebugPrintAt(screen, tokensLabel, x+theme.CardTextPadding, tokensY)
 }
 
 // getUsageColor returns a color based on context usage percentage.
 func getUsageColor(usage float64) color.RGBA {
 	if usage < 0.5 {
-		return color.RGBA{R: 0x2E, G: 0x7D, B: 0x32, A: 0xFF} // Green
+		return theme.StatusSuccess
 	} else if usage < 0.8 {
-		return color.RGBA{R: 0xF5, G: 0x7F, B: 0x17, A: 0xFF} // Orange
+		return theme.StatusWarning
 	}
-	return color.RGBA{R: 0xC6, G: 0x28, B: 0x28, A: 0xFF} // Red
+	return theme.StatusError
 }
 
 func clampUnitInterval(value float64) float64 {

--- a/internal/multiagent/renderer_test.go
+++ b/internal/multiagent/renderer_test.go
@@ -1,7 +1,10 @@
 package multiagent
 
 import (
+	"image/color"
 	"testing"
+
+	"github.com/tedks/CodingGame/internal/theme"
 )
 
 func TestNewRenderer(t *testing.T) {
@@ -14,38 +17,36 @@ func TestNewRenderer(t *testing.T) {
 func TestGetStatusColor(t *testing.T) {
 	tests := []struct {
 		status   AgentStatus
-		expected [4]uint8 // R, G, B, A
+		expected color.RGBA
 	}{
-		{StatusIdle, [4]uint8{0x75, 0x75, 0x75, 0xFF}},      // Gray
-		{StatusWorking, [4]uint8{0x2E, 0x7D, 0x32, 0xFF}},   // Green
-		{StatusPaused, [4]uint8{0xF5, 0x7F, 0x17, 0xFF}},    // Orange
-		{StatusCompleted, [4]uint8{0x19, 0x76, 0xD2, 0xFF}}, // Blue
-		{StatusError, [4]uint8{0xC6, 0x28, 0x28, 0xFF}},     // Red
+		{StatusIdle, theme.StatusNeutral},
+		{StatusWorking, theme.StatusSuccess},
+		{StatusPaused, theme.StatusWarning},
+		{StatusCompleted, theme.StatusInfo},
+		{StatusError, theme.StatusError},
 	}
 
 	for _, tc := range tests {
 		c := GetStatusColor(tc.status)
-		if c.R != tc.expected[0] || c.G != tc.expected[1] || c.B != tc.expected[2] || c.A != tc.expected[3] {
-			t.Errorf("GetStatusColor(%v) = (%d,%d,%d,%d), expected (%d,%d,%d,%d)",
-				tc.status, c.R, c.G, c.B, c.A,
-				tc.expected[0], tc.expected[1], tc.expected[2], tc.expected[3])
+		if c != tc.expected {
+			t.Errorf("GetStatusColor(%v) = %v, expected %v", tc.status, c, tc.expected)
 		}
 	}
 }
 
 func TestLayoutConstants(t *testing.T) {
 	// Verify layout constants are reasonable
-	if agentCardWidth <= 0 {
-		t.Error("agentCardWidth should be positive")
+	if theme.MultiAgentCardWidth <= 0 {
+		t.Error("MultiAgentCardWidth should be positive")
 	}
-	if agentCardHeight <= 0 {
-		t.Error("agentCardHeight should be positive")
+	if theme.MultiAgentCardHeight <= 0 {
+		t.Error("MultiAgentCardHeight should be positive")
 	}
-	if agentCardsPerRow <= 0 {
-		t.Error("agentCardsPerRow should be positive")
+	if theme.MultiAgentCardsPerRow <= 0 {
+		t.Error("MultiAgentCardsPerRow should be positive")
 	}
-	if agentHeaderHeight <= 0 {
-		t.Error("agentHeaderHeight should be positive")
+	if theme.PanelHeaderHeight <= 0 {
+		t.Error("PanelHeaderHeight should be positive")
 	}
 }
 
@@ -113,8 +114,9 @@ func TestTokenSummaryXGuard(t *testing.T) {
 		t.Error("expected guard to skip token summary for narrow width")
 	}
 
-	want := x + 300 - 200
-	got, ok := tokenSummaryX(x, 300)
+	width := 300
+	want := x + width - theme.MultiAgentTokenSummaryWidth
+	got, ok := tokenSummaryX(x, width)
 	if !ok {
 		t.Fatal("expected token summary to render for wide width")
 	}

--- a/internal/production/BUILD.bazel
+++ b/internal/production/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "@com_github_hajimehoshi_ebiten_v2//:ebiten",
         "@com_github_hajimehoshi_ebiten_v2//ebitenutil",
         "@com_github_hajimehoshi_ebiten_v2//vector",
+        "//internal/theme",
     ],
 )
 

--- a/internal/production/renderer.go
+++ b/internal/production/renderer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/vector"
+	"github.com/tedks/CodingGame/internal/theme"
 )
 
 // Renderer draws the production environment visualization.
@@ -18,22 +19,12 @@ func NewRenderer() *Renderer {
 	return &Renderer{}
 }
 
-// Layout constants
-const (
-	prodPadding      = 20
-	prodCityWidth    = 180
-	prodCityHeight   = 100
-	prodCitySpacing  = 30
-	prodCitiesPerRow = 4
-	prodHeaderHeight = 60
-)
-
 // Color scheme for health statuses
 var healthColors = map[HealthStatus]color.RGBA{
-	HealthHealthy:   {R: 0x2E, G: 0x7D, B: 0x32, A: 0xFF}, // Green
-	HealthDegraded:  {R: 0xF5, G: 0x7F, B: 0x17, A: 0xFF}, // Orange
-	HealthUnhealthy: {R: 0xC6, G: 0x28, B: 0x28, A: 0xFF}, // Red
-	HealthUnknown:   {R: 0x75, G: 0x75, B: 0x75, A: 0xFF}, // Gray
+	HealthHealthy:   theme.StatusSuccess,
+	HealthDegraded:  theme.StatusWarning,
+	HealthUnhealthy: theme.StatusError,
+	HealthUnknown:   theme.StatusNeutral,
 }
 
 // Draw renders the production view to the screen.
@@ -48,21 +39,21 @@ func (r *Renderer) Draw(screen *ebiten.Image, services []*Service, x, y, width, 
 
 	// If no services, show empty state
 	if len(services) == 0 {
-		r.drawEmptyState(screen, x, y+prodHeaderHeight, width, height-prodHeaderHeight)
+		r.drawEmptyState(screen, x, y+theme.PanelHeaderHeight, width, height-theme.PanelHeaderHeight)
 		return
 	}
 
 	// Draw services as cities
-	startY := y + prodHeaderHeight + prodPadding
+	startY := y + theme.PanelHeaderHeight + theme.PanelPadding
 	for i, svc := range services {
-		row := i / prodCitiesPerRow
-		col := i % prodCitiesPerRow
+		row := i / theme.ProductionCitiesPerRow
+		col := i % theme.ProductionCitiesPerRow
 
-		cityX := x + prodPadding + col*(prodCityWidth+prodCitySpacing)
-		cityY := startY + row*(prodCityHeight+prodCitySpacing)
+		cityX := x + theme.PanelPadding + col*(theme.ProductionCityWidth+theme.ProductionCitySpacing)
+		cityY := startY + row*(theme.ProductionCityHeight+theme.ProductionCitySpacing)
 
 		// Check if we're still in bounds
-		if cityY+prodCityHeight > y+height {
+		if cityY+theme.ProductionCityHeight > y+height {
 			break
 		}
 
@@ -71,22 +62,17 @@ func (r *Renderer) Draw(screen *ebiten.Image, services []*Service, x, y, width, 
 }
 
 func weatherSummaryX(x, width int) (int, bool) {
-	weatherX := x + width - 300
-	minX := x + prodPadding
-	if weatherX < minX {
-		return minX, false
-	}
-	return weatherX, true
+	return theme.RightAlignedX(x, width, theme.ProductionWeatherSummaryWidth, theme.PanelPadding)
 }
 
 // drawHeader renders the summary header with weather overview.
 func (r *Renderer) drawHeader(screen *ebiten.Image, services []*Service, x, y, width int) {
 	// Draw background
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(width), float32(prodHeaderHeight),
-		color.RGBA{R: 0x1A, G: 0x1A, B: 0x2E, A: 0xFF}, false)
+	vector.DrawFilledRect(screen, float32(x), float32(y), float32(width), float32(theme.PanelHeaderHeight),
+		theme.HeaderBackground, false)
 
 	// Draw title
-	ebitenutil.DebugPrintAt(screen, "PRODUCTION REALM", x+prodPadding, y+10)
+	ebitenutil.DebugPrintAt(screen, "PRODUCTION REALM", x+theme.PanelPadding, y+theme.PanelHeaderTitleOffsetY)
 
 	// Calculate health summary
 	healthCounts := make(map[HealthStatus]int)
@@ -97,8 +83,8 @@ func (r *Renderer) drawHeader(screen *ebiten.Image, services []*Service, x, y, w
 	}
 
 	// Draw health summary
-	summaryY := y + 30
-	summaryX := x + prodPadding
+	summaryY := y + theme.PanelHeaderSummaryOffsetY
+	summaryX := x + theme.PanelPadding
 	healthy := healthCounts[HealthHealthy]
 	degraded := healthCounts[HealthDegraded]
 	unhealthy := healthCounts[HealthUnhealthy]
@@ -122,9 +108,9 @@ func (r *Renderer) drawEmptyState(screen *ebiten.Image, x, y, width, height int)
 	hint := "Add a .production.json file to monitor services"
 
 	// Center the messages
-	msgX := x + width/2 - len(msg)*3
-	msgY := y + height/2 - 20
-	hintX := x + width/2 - len(hint)*3
+	msgX := theme.CenterTextX(x, width, msg, theme.CompactTextCharWidth)
+	msgY := y + height/2 - theme.EmptyStateLineOffset
+	hintX := theme.CenterTextX(x, width, hint, theme.CompactTextCharWidth)
 	hintY := y + height/2
 
 	ebitenutil.DebugPrintAt(screen, msg, msgX, msgY)
@@ -137,45 +123,44 @@ func (r *Renderer) drawCity(screen *ebiten.Image, svc *Service, x, y int) {
 	healthColor := healthColors[svc.Health]
 
 	// Draw city background
-	bgColor := color.RGBA{R: 0x2A, G: 0x2A, B: 0x3E, A: 0xFF}
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(prodCityWidth), float32(prodCityHeight),
-		bgColor, false)
+	vector.DrawFilledRect(screen, float32(x), float32(y), float32(theme.ProductionCityWidth), float32(theme.ProductionCityHeight),
+		theme.CardBackground, false)
 
 	// Draw health indicator border
-	vector.StrokeRect(screen, float32(x), float32(y), float32(prodCityWidth), float32(prodCityHeight),
-		2, healthColor, false)
+	vector.StrokeRect(screen, float32(x), float32(y), float32(theme.ProductionCityWidth), float32(theme.ProductionCityHeight),
+		theme.CardBorderWidth, healthColor, false)
 
 	// Draw service name
-	nameY := y + 8
-	ebitenutil.DebugPrintAt(screen, svc.Name, x+8, nameY)
+	nameY := y + theme.ProductionNameOffsetY
+	ebitenutil.DebugPrintAt(screen, svc.Name, x+theme.CardTextPadding, nameY)
 
 	// Draw service type
-	typeY := y + 24
+	typeY := y + theme.ProductionTypeOffsetY
 	typeStr := fmt.Sprintf("[%s]", svc.Type)
-	ebitenutil.DebugPrintAt(screen, typeStr, x+8, typeY)
+	ebitenutil.DebugPrintAt(screen, typeStr, x+theme.CardTextPadding, typeY)
 
 	// Draw weather indicator
-	weatherY := y + 40
+	weatherY := y + theme.ProductionWeatherOffsetY
 	weatherStr := r.weatherDisplay(svc.Weather)
-	ebitenutil.DebugPrintAt(screen, weatherStr, x+8, weatherY)
+	ebitenutil.DebugPrintAt(screen, weatherStr, x+theme.CardTextPadding, weatherY)
 
 	// Draw health status
-	healthY := y + 56
+	healthY := y + theme.ProductionHealthOffsetY
 	healthStr := fmt.Sprintf("Status: %s", svc.Health)
-	ebitenutil.DebugPrintAt(screen, healthStr, x+8, healthY)
+	ebitenutil.DebugPrintAt(screen, healthStr, x+theme.CardTextPadding, healthY)
 
 	// Draw traffic if available
 	if svc.Metrics.RequestsPerSecond > 0 {
-		trafficY := y + 72
+		trafficY := y + theme.ProductionTrafficOffsetY
 		trafficStr := fmt.Sprintf("%.1f req/s", svc.Metrics.RequestsPerSecond)
-		ebitenutil.DebugPrintAt(screen, trafficStr, x+8, trafficY)
+		ebitenutil.DebugPrintAt(screen, trafficStr, x+theme.CardTextPadding, trafficY)
 	}
 
 	// Draw dependency count
 	if len(svc.Dependencies) > 0 {
-		depY := y + 72
+		depY := y + theme.ProductionDependencyOffsetY
 		depStr := fmt.Sprintf("Deps: %d", len(svc.Dependencies))
-		ebitenutil.DebugPrintAt(screen, depStr, x+prodCityWidth-60, depY)
+		ebitenutil.DebugPrintAt(screen, depStr, x+theme.ProductionCityWidth-theme.ProductionDependencyInset, depY)
 	}
 }
 

--- a/internal/production/renderer_test.go
+++ b/internal/production/renderer_test.go
@@ -1,7 +1,10 @@
 package production
 
 import (
+	"image/color"
 	"testing"
+
+	"github.com/tedks/CodingGame/internal/theme"
 )
 
 func TestNewRenderer(t *testing.T) {
@@ -14,20 +17,18 @@ func TestNewRenderer(t *testing.T) {
 func TestGetHealthColor(t *testing.T) {
 	tests := []struct {
 		health   HealthStatus
-		expected [4]uint8 // R, G, B, A
+		expected color.RGBA
 	}{
-		{HealthHealthy, [4]uint8{0x2E, 0x7D, 0x32, 0xFF}},   // Green
-		{HealthDegraded, [4]uint8{0xF5, 0x7F, 0x17, 0xFF}},  // Orange
-		{HealthUnhealthy, [4]uint8{0xC6, 0x28, 0x28, 0xFF}}, // Red
-		{HealthUnknown, [4]uint8{0x75, 0x75, 0x75, 0xFF}},   // Gray
+		{HealthHealthy, theme.StatusSuccess},
+		{HealthDegraded, theme.StatusWarning},
+		{HealthUnhealthy, theme.StatusError},
+		{HealthUnknown, theme.StatusNeutral},
 	}
 
 	for _, tc := range tests {
 		c := GetHealthColor(tc.health)
-		if c.R != tc.expected[0] || c.G != tc.expected[1] || c.B != tc.expected[2] || c.A != tc.expected[3] {
-			t.Errorf("GetHealthColor(%v) = (%d,%d,%d,%d), expected (%d,%d,%d,%d)",
-				tc.health, c.R, c.G, c.B, c.A,
-				tc.expected[0], tc.expected[1], tc.expected[2], tc.expected[3])
+		if c != tc.expected {
+			t.Errorf("GetHealthColor(%v) = %v, expected %v", tc.health, c, tc.expected)
 		}
 	}
 }
@@ -72,8 +73,9 @@ func TestWeatherSummaryXGuard(t *testing.T) {
 		t.Error("expected guard to skip weather summary for narrow width")
 	}
 
-	want := x + 500 - 300
-	got, ok := weatherSummaryX(x, 500)
+	width := 500
+	want := x + width - theme.ProductionWeatherSummaryWidth
+	got, ok := weatherSummaryX(x, width)
 	if !ok {
 		t.Fatal("expected weather summary to render for wide width")
 	}
@@ -84,17 +86,17 @@ func TestWeatherSummaryXGuard(t *testing.T) {
 
 func TestLayoutConstants(t *testing.T) {
 	// Verify layout constants are reasonable
-	if prodCityWidth <= 0 {
-		t.Error("prodCityWidth should be positive")
+	if theme.ProductionCityWidth <= 0 {
+		t.Error("ProductionCityWidth should be positive")
 	}
-	if prodCityHeight <= 0 {
-		t.Error("prodCityHeight should be positive")
+	if theme.ProductionCityHeight <= 0 {
+		t.Error("ProductionCityHeight should be positive")
 	}
-	if prodCitiesPerRow <= 0 {
-		t.Error("prodCitiesPerRow should be positive")
+	if theme.ProductionCitiesPerRow <= 0 {
+		t.Error("ProductionCitiesPerRow should be positive")
 	}
-	if prodHeaderHeight <= 0 {
-		t.Error("prodHeaderHeight should be positive")
+	if theme.PanelHeaderHeight <= 0 {
+		t.Error("PanelHeaderHeight should be positive")
 	}
 }
 

--- a/internal/resources/BUILD.bazel
+++ b/internal/resources/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "@com_github_hajimehoshi_ebiten_v2//:ebiten",
         "@com_github_hajimehoshi_ebiten_v2//ebitenutil",
         "@com_github_hajimehoshi_ebiten_v2//vector",
+        "//internal/theme",
     ],
 )
 

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/vector"
+	"github.com/tedks/CodingGame/internal/theme"
 )
 
 // Resource represents a trackable metric displayed in the resource bar
@@ -44,25 +45,25 @@ func New() *Tracker {
 				Current: 0,
 				Max:     200000, // 200k tokens
 				Unit:    "tokens",
-				Color:   color.RGBA{100, 150, 255, 255}, // Blue
+				Color:   theme.ResourceContext,
 			},
 			{
 				Name:    "API Cost",
 				Current: 0,
 				Max:     10000, // $100.00 (in cents)
 				Unit:    "cents",
-				Color:   color.RGBA{255, 200, 100, 255}, // Gold
+				Color:   theme.ResourceCost,
 			},
 			{
 				Name:    "Coverage",
 				Current: 0,
 				Max:     100, // Percentage
 				Unit:    "%",
-				Color:   color.RGBA{100, 255, 150, 255}, // Green
+				Color:   theme.ResourceCoverage,
 			},
 		},
-		bgColor:   color.RGBA{30, 30, 40, 255},
-		textColor: color.RGBA{200, 200, 220, 255},
+		bgColor:   theme.ResourcePanelBackground,
+		textColor: theme.ResourceText,
 	}
 }
 
@@ -106,7 +107,7 @@ func (t *Tracker) Draw(screen *ebiten.Image, x, y, width, height int) {
 
 // drawResource renders a single resource meter
 func (t *Tracker) drawResource(screen *ebiten.Image, r *Resource, x, y, width, height int) {
-	padding := 10
+	padding := theme.ResourcePadding
 
 	// Calculate fill percentage
 	fillPct := float32(0)
@@ -115,8 +116,8 @@ func (t *Tracker) drawResource(screen *ebiten.Image, r *Resource, x, y, width, h
 	}
 
 	// Draw resource bar background
-	barY := float32(y + height - 10)
-	barHeight := float32(5)
+	barY := float32(y + height - theme.ResourceBarBottomInset)
+	barHeight := float32(theme.ResourceBarHeight)
 	barWidth := float32(width - 2*padding)
 
 	vector.DrawFilledRect(
@@ -125,7 +126,7 @@ func (t *Tracker) drawResource(screen *ebiten.Image, r *Resource, x, y, width, h
 		barY,
 		barWidth,
 		barHeight,
-		color.RGBA{50, 50, 60, 255},
+		theme.ResourceBarBackground,
 		false,
 	)
 
@@ -144,7 +145,7 @@ func (t *Tracker) drawResource(screen *ebiten.Image, r *Resource, x, y, width, h
 
 	// Draw resource text
 	text := t.formatResourceText(r)
-	ebitenutil.DebugPrintAt(screen, text, x+padding, y+5)
+	ebitenutil.DebugPrintAt(screen, text, x+padding, y+theme.ResourceTextOffsetY)
 }
 
 func clampRatio(value float32) float32 {

--- a/internal/theme/BUILD.bazel
+++ b/internal/theme/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "theme",
+    srcs = [
+        "helpers.go",
+        "layout.go",
+        "palette.go",
+    ],
+    importpath = "github.com/tedks/CodingGame/internal/theme",
+    visibility = ["//visibility:public"],
+)

--- a/internal/theme/helpers.go
+++ b/internal/theme/helpers.go
@@ -1,0 +1,22 @@
+package theme
+
+// RightAlignedX returns the x coordinate for an element aligned to the right edge.
+// It returns ok=false when the element would overlap the minimum padding.
+func RightAlignedX(x, width, elementWidth, minPadding int) (alignedX int, ok bool) {
+	alignedX = x + width - elementWidth
+	minX := x + minPadding
+	if alignedX < minX {
+		return minX, false
+	}
+	return alignedX, true
+}
+
+// CenterTextX approximates centering text by character width.
+func CenterTextX(x, width int, text string, charWidth int) int {
+	return x + (width-len(text)*charWidth)/2
+}
+
+// CenterTextY centers a single line of text with a known line height.
+func CenterTextY(y, height, lineHeight int) int {
+	return y + (height-lineHeight)/2
+}

--- a/internal/theme/layout.go
+++ b/internal/theme/layout.go
@@ -1,0 +1,68 @@
+package theme
+
+const (
+	PanelPadding              = 20
+	PanelHeaderHeight         = 60
+	PanelHeaderTitleOffsetY   = 10
+	PanelHeaderSummaryOffsetY = 30
+	CardTextPadding           = 8
+	CardBorderWidth           = 2
+	EmptyStateLineOffset      = 20
+	CompactTextCharWidth      = 3
+)
+
+const (
+	MultiAgentCardWidth         = 200
+	MultiAgentCardHeight        = 120
+	MultiAgentCardSpacing       = 20
+	MultiAgentCardsPerRow       = 4
+	MultiAgentTokenSummaryWidth = 200
+	MultiAgentNameOffsetY       = 8
+	MultiAgentStatusOffsetY     = 24
+	MultiAgentTaskOffsetY       = 44
+	MultiAgentUsageOffsetY      = 68
+	MultiAgentUsageBarHeight    = 12
+	MultiAgentUsageLabelOffsetY = 84
+	MultiAgentTokensOffsetY     = 100
+)
+
+const (
+	ProductionCityWidth           = 180
+	ProductionCityHeight          = 100
+	ProductionCitySpacing         = 30
+	ProductionCitiesPerRow        = 4
+	ProductionWeatherSummaryWidth = 300
+	ProductionNameOffsetY         = 8
+	ProductionTypeOffsetY         = 24
+	ProductionWeatherOffsetY      = 40
+	ProductionHealthOffsetY       = 56
+	ProductionTrafficOffsetY      = 72
+	ProductionDependencyOffsetY   = 72
+	ProductionDependencyInset     = 60
+)
+
+const (
+	CapabilityColumnWidth         = 200
+	CapabilityNodeHeight          = 40
+	CapabilityNodeMargin          = 8
+	CapabilityHeaderHeight        = 30
+	CapabilityPadding             = 16
+	CapabilityTitleHeight         = 20
+	CapabilityLegendHeight        = 40
+	CapabilityHeaderCharWidth     = 7
+	CapabilityHeaderLineHeight    = 14
+	CapabilityNodeAccentWidth     = 4
+	CapabilityNodeNameOffsetY     = 6
+	CapabilityNodeTypeOffsetY     = 22
+	CapabilityLegendSwatchSize    = 10
+	CapabilityLegendSwatchYOffset = 2
+	CapabilityLegendTextOffsetX   = 14
+	CapabilityLegendItemSpacing   = 30
+)
+
+const (
+	ResourcePadding        = 10
+	ResourceTextOffsetY    = 5
+	ResourceBarHeight      = 5
+	ResourceBarBottomInset = 10
+)

--- a/internal/theme/palette.go
+++ b/internal/theme/palette.go
@@ -1,0 +1,38 @@
+package theme
+
+import "image/color"
+
+// Shared palette for UI renderers. Treat these as read-only values.
+var (
+	HeaderBackground   = color.RGBA{R: 0x1A, G: 0x1A, B: 0x2E, A: 0xFF}
+	CardBackground     = color.RGBA{R: 0x2A, G: 0x2A, B: 0x3E, A: 0xFF}
+	UsageBarBackground = color.RGBA{R: 0x40, G: 0x40, B: 0x40, A: 0xFF}
+
+	StatusNeutral = color.RGBA{R: 0x75, G: 0x75, B: 0x75, A: 0xFF}
+	StatusSuccess = color.RGBA{R: 0x2E, G: 0x7D, B: 0x32, A: 0xFF}
+	StatusWarning = color.RGBA{R: 0xF5, G: 0x7F, B: 0x17, A: 0xFF}
+	StatusInfo    = color.RGBA{R: 0x19, G: 0x76, B: 0xD2, A: 0xFF}
+	StatusError   = color.RGBA{R: 0xC6, G: 0x28, B: 0x28, A: 0xFF}
+
+	ResourcePanelBackground = color.RGBA{R: 30, G: 30, B: 40, A: 255}
+	ResourceBarBackground   = color.RGBA{R: 50, G: 50, B: 60, A: 255}
+	ResourceText            = color.RGBA{R: 200, G: 200, B: 220, A: 255}
+	ResourceContext         = color.RGBA{R: 100, G: 150, B: 255, A: 255}
+	ResourceCost            = color.RGBA{R: 255, G: 200, B: 100, A: 255}
+	ResourceCoverage        = color.RGBA{R: 100, G: 255, B: 150, A: 255}
+
+	CapabilityBackground     = color.RGBA{R: 20, G: 25, B: 30, A: 255}
+	CapabilityNodeBackground = color.RGBA{R: 40, G: 45, B: 50, A: 255}
+	CapabilityNodeDisabled   = color.RGBA{R: 30, G: 30, B: 30, A: 200}
+
+	CapabilityDomainCore        = color.RGBA{R: 60, G: 80, B: 100, A: 255}
+	CapabilityDomainBuild       = color.RGBA{R: 80, G: 100, B: 60, A: 255}
+	CapabilityDomainVersionCtrl = color.RGBA{R: 100, G: 80, B: 60, A: 255}
+	CapabilityDomainDeployment  = color.RGBA{R: 80, G: 60, B: 100, A: 255}
+	CapabilityDomainAnalysis    = color.RGBA{R: 60, G: 100, B: 80, A: 255}
+
+	CapabilityTypeTool        = color.RGBA{R: 100, G: 180, B: 255, A: 255}
+	CapabilityTypeMCP         = color.RGBA{R: 255, G: 180, B: 100, A: 255}
+	CapabilityTypeCommand     = color.RGBA{R: 180, G: 100, B: 255, A: 255}
+	CapabilityTypeIntegration = color.RGBA{R: 100, G: 255, B: 180, A: 255}
+)


### PR DESCRIPTION
## Summary
- Create internal/theme package with centralized constants
- Replace magic numbers with theme constants across renderers
- Improve maintainability and consistency

## Test Plan
- [x] All tests pass
- [x] Race detector passes

Co-Authored-By: Codex <noreply@openai.com>